### PR TITLE
[STOR-3] 근거 부족 시 추가 질문 또는 답변 보류

### DIFF
--- a/agents/store_ops_agent/app/core/__init__.py
+++ b/agents/store_ops_agent/app/core/__init__.py
@@ -1,6 +1,13 @@
 """Core configuration and utilities package."""
 
+from app.core.answer_orchestrator import AnswerOrchestrator, OrchestratorConfig
 from app.core.citation_formatter import CitationFormatter
+from app.core.followup_generator import FollowUpGenerator
+from app.core.grounding_checker import (
+    FailSafePolicy,
+    GroundingChecker,
+    GroundingResult,
+)
 from app.core.tracing import (
     MetricsCollector,
     RequestTracer,
@@ -9,8 +16,14 @@ from app.core.tracing import (
 )
 
 __all__ = [
+    "AnswerOrchestrator",
     "CitationFormatter",
+    "FailSafePolicy",
+    "FollowUpGenerator",
+    "GroundingChecker",
+    "GroundingResult",
     "MetricsCollector",
+    "OrchestratorConfig",
     "RequestTracer",
     "generate_trace_id",
     "trace_request",

--- a/agents/store_ops_agent/app/core/answer_orchestrator.py
+++ b/agents/store_ops_agent/app/core/answer_orchestrator.py
@@ -1,0 +1,261 @@
+"""Answer orchestrator with retry logic and fail-safe handling.
+
+This module coordinates the answer generation process, including:
+- Document retrieval with retry logic
+- Grounding check for evidence validation
+- Follow-up question generation
+- Fail-safe policy enforcement
+"""
+
+from dataclasses import dataclass
+from typing import Callable, Optional, Protocol
+
+from app.core.followup_generator import FollowUpGenerator
+from app.core.grounding_checker import FailSafePolicy, GroundingChecker, GroundingResult
+from app.core.tracing import RequestTracer
+from app.models.schemas import AnswerResponse, Citation, ConflictInfo, Meta, Verdict
+
+
+class RetrieverProtocol(Protocol):
+    """Protocol for document retrieval."""
+
+    async def retrieve(
+        self,
+        query: str,
+        topk: int,
+    ) -> list[Citation]:
+        """Retrieve relevant documents for a query."""
+        ...
+
+
+@dataclass
+class OrchestratorConfig:
+    """Configuration for the answer orchestrator."""
+
+    max_retrieval_attempts: int = 2  # Max 1 retry = 2 total attempts
+    min_citations: int = 1
+    min_score_threshold: float = 0.6
+    max_followup_questions: int = 3
+
+
+class AnswerOrchestrator:
+    """Orchestrates the answer generation process with fail-safe handling.
+
+    This class coordinates:
+    1. Document retrieval (with max 1 retry)
+    2. Grounding check for evidence validation
+    3. Follow-up question generation when evidence is insufficient
+    4. Answer generation or withholding based on fail-safe policy
+    """
+
+    def __init__(
+        self,
+        config: Optional[OrchestratorConfig] = None,
+    ) -> None:
+        """Initialize the orchestrator.
+
+        Args:
+            config: Configuration for the orchestrator.
+        """
+        self.config = config or OrchestratorConfig()
+        self.grounding_checker = GroundingChecker(
+            min_citations=self.config.min_citations,
+            min_score_threshold=self.config.min_score_threshold,
+        )
+        self.followup_generator = FollowUpGenerator(
+            max_questions=self.config.max_followup_questions,
+        )
+
+    async def process_question(
+        self,
+        question: str,
+        topk: int,
+        tracer: RequestTracer,
+        retriever: RetrieverProtocol,
+        answer_generator: Optional[Callable[[str, list[Citation]], str]] = None,
+    ) -> AnswerResponse:
+        """Process a question with retry logic and fail-safe handling.
+
+        Args:
+            question: The user's question.
+            topk: Number of documents to retrieve.
+            tracer: Request tracer for metrics.
+            retriever: Document retriever implementation.
+            answer_generator: Optional function to generate answer from citations.
+
+        Returns:
+            AnswerResponse with answer, citations, and metadata.
+        """
+        citations: list[Citation] = []
+        grounding_result: Optional[GroundingResult] = None
+        attempt = 0
+
+        # Retrieval loop with max 1 retry
+        while attempt < self.config.max_retrieval_attempts:
+            attempt += 1
+            tracer.record_retrieval_attempt()
+
+            # Retrieve documents
+            citations = await retriever.retrieve(question, topk)
+
+            # Perform grounding check
+            grounding_result = self.grounding_checker.check(citations, question)
+
+            # If we have sufficient evidence, break out of retry loop
+            if grounding_result.is_sufficient:
+                break
+
+            # If it's the first attempt and evidence is insufficient (not conflict),
+            # we can retry with modified query or expanded search
+            if attempt == 1 and grounding_result.verdict in (
+                Verdict.NOT_FOUND,
+                Verdict.INSUFFICIENT,
+            ):
+                # Continue to retry
+                continue
+
+            # For conflicts or second attempt, don't retry further
+            break
+
+        # At this point, we have the final citations and grounding result
+        if grounding_result is None:
+            grounding_result = GroundingResult(
+                verdict=Verdict.NOT_FOUND,
+                is_sufficient=False,
+                withheld_reason="검색을 수행할 수 없습니다.",
+            )
+
+        # Set verdict on tracer
+        tracer.set_verdict(grounding_result.verdict)
+
+        # Determine if answer should be withheld
+        should_withhold = FailSafePolicy.should_withhold_answer(grounding_result)
+
+        # Generate answer or withheld message
+        if should_withhold:
+            answer = FailSafePolicy.get_withheld_message(grounding_result)
+        elif grounding_result.verdict == Verdict.CONFLICT and grounding_result.recommended_citation:
+            # For conflicts, provide cautious answer based on recommended citation
+            if answer_generator:
+                answer = answer_generator(question, [grounding_result.recommended_citation])
+            else:
+                answer = self._generate_conflict_answer(
+                    question,
+                    grounding_result.recommended_citation,
+                    grounding_result.conflict_info,
+                )
+        else:
+            # Generate normal answer
+            if answer_generator:
+                answer = answer_generator(question, citations)
+            else:
+                answer = self._generate_default_answer(question, citations)
+
+        # Generate follow-up questions
+        follow_up_questions = self.followup_generator.generate(
+            verdict=grounding_result.verdict,
+            question=question,
+            citations=citations,
+        )
+
+        # Build response
+        return AnswerResponse(
+            answer=answer,
+            citations=citations,
+            follow_up_questions=follow_up_questions if follow_up_questions else None,
+            withheld=should_withhold,
+            withheld_reason=grounding_result.withheld_reason if should_withhold else None,
+            meta=self._build_meta(tracer, grounding_result),
+        )
+
+    def _generate_default_answer(
+        self,
+        question: str,
+        citations: list[Citation],
+    ) -> str:
+        """Generate a default answer based on citations.
+
+        This is a placeholder for actual LLM-based answer generation.
+
+        Args:
+            question: The user's question.
+            citations: Retrieved citations.
+
+        Returns:
+            Generated answer string.
+        """
+        if not citations:
+            return "관련 정보를 찾을 수 없습니다."
+
+        # In real implementation, this would use an LLM
+        top_citation = max(citations, key=lambda c: c.score)
+        return (
+            f"'{question}'에 대한 답변입니다. "
+            f"'{top_citation.title}' 문서에 따르면, {top_citation.snippet} "
+            "자세한 내용은 아래 근거 자료를 참고해 주세요."
+        )
+
+    def _generate_conflict_answer(
+        self,
+        question: str,
+        recommended_citation: Citation,
+        conflict_info: Optional[ConflictInfo],
+    ) -> str:
+        """Generate answer for conflict scenario.
+
+        Args:
+            question: The user's question.
+            recommended_citation: The recommended citation after conflict resolution.
+            conflict_info: Information about the conflict.
+
+        Returns:
+            Answer with conflict notice.
+        """
+        resolution_note = ""
+        if conflict_info and conflict_info.resolution_basis:
+            if conflict_info.resolution_basis == "effective_date":
+                resolution_note = f"(적용일 {recommended_citation.effective_date} 기준)"
+            elif conflict_info.resolution_basis == "version":
+                resolution_note = f"(버전 {recommended_citation.version} 기준)"
+
+        return (
+            f"⚠️ 문서 간 상충되는 정보가 발견되었습니다. "
+            f"최신 정보 {resolution_note}를 기준으로 안내해 드립니다.\n\n"
+            f"'{recommended_citation.title}' 문서에 따르면: {recommended_citation.snippet}\n\n"
+            "정확한 확인이 필요하시면 담당자에게 문의해 주세요."
+        )
+
+    def _build_meta(
+        self,
+        tracer: RequestTracer,
+        grounding_result: GroundingResult,
+    ) -> Meta:
+        """Build Meta object from tracer and grounding result.
+
+        Args:
+            tracer: Request tracer with timing and attempt info.
+            grounding_result: Result of grounding check.
+
+        Returns:
+            Meta object for response.
+        """
+        base_meta = tracer.to_meta()
+
+        # Add conflict info if present
+        if grounding_result.conflict_info:
+            return Meta(
+                trace_id=base_meta.trace_id,
+                topk=base_meta.topk,
+                retrieval_attempts=base_meta.retrieval_attempts,
+                latency_ms=base_meta.latency_ms,
+                verdict=grounding_result.verdict,
+                conflict_info=grounding_result.conflict_info,
+            )
+
+        return Meta(
+            trace_id=base_meta.trace_id,
+            topk=base_meta.topk,
+            retrieval_attempts=base_meta.retrieval_attempts,
+            latency_ms=base_meta.latency_ms,
+            verdict=grounding_result.verdict,
+        )

--- a/agents/store_ops_agent/app/core/followup_generator.py
+++ b/agents/store_ops_agent/app/core/followup_generator.py
@@ -1,0 +1,205 @@
+"""Follow-up question generator for insufficient evidence scenarios.
+
+This module generates context-aware follow-up questions when the system
+cannot provide a definitive answer due to insufficient or conflicting evidence.
+"""
+
+from typing import Optional
+
+from app.models.schemas import Citation, Verdict
+
+
+class FollowUpGenerator:
+    """Generates follow-up questions based on context and verdict.
+
+    When evidence is insufficient or conflicting, this generator creates
+    relevant follow-up questions to help users refine their queries.
+    """
+
+    # Template follow-up questions for different scenarios
+    TEMPLATES = {
+        Verdict.NOT_FOUND: [
+            "어떤 종류의 문서에서 정보를 찾고 계신가요? (예: 매뉴얼, 규정, 가이드)",
+            "질문하신 내용과 관련된 특정 키워드가 있으신가요?",
+            "언제 적용되는 정보인지 알려주시겠어요? (예: 현재, 특정 날짜)",
+        ],
+        Verdict.INSUFFICIENT: [
+            "조금 더 구체적으로 어떤 상황에 대해 알고 싶으신가요?",
+            "특정 매장이나 부서에 관한 질문인가요?",
+            "관련 규정이나 매뉴얼 이름을 알고 계신가요?",
+        ],
+        Verdict.CONFLICT: [
+            "어느 시점의 정보가 필요하신가요? (최신 vs 특정 시점)",
+            "특정 버전의 문서를 찾고 계신가요?",
+            "담당 부서에서 확인받으신 내용이 있으신가요?",
+        ],
+        Verdict.PARTIAL: [
+            "추가로 알고 싶으신 부분이 있으신가요?",
+            "다른 관련 정보도 필요하신가요?",
+        ],
+    }
+
+    def __init__(self, max_questions: int = 3) -> None:
+        """Initialize the follow-up generator.
+
+        Args:
+            max_questions: Maximum number of follow-up questions to generate.
+        """
+        self.max_questions = max_questions
+
+    def generate(
+        self,
+        verdict: Verdict,
+        question: str,
+        citations: Optional[list[Citation]] = None,
+    ) -> list[str]:
+        """Generate follow-up questions based on verdict and context.
+
+        Args:
+            verdict: The grounding check verdict.
+            question: The original user question.
+            citations: Available citations (may be empty or partial).
+
+        Returns:
+            List of follow-up questions.
+        """
+        questions = []
+
+        # Add context-specific question based on the original question
+        context_question = self._generate_context_question(question, verdict)
+        if context_question:
+            questions.append(context_question)
+
+        # Add citation-based questions if available
+        if citations:
+            citation_questions = self._generate_citation_questions(citations, verdict)
+            questions.extend(citation_questions)
+
+        # Add template questions for the verdict type
+        template_questions = self.TEMPLATES.get(verdict, [])
+        for tq in template_questions:
+            if tq not in questions:
+                questions.append(tq)
+                if len(questions) >= self.max_questions:
+                    break
+
+        return questions[: self.max_questions]
+
+    def _generate_context_question(
+        self,
+        question: str,
+        verdict: Verdict,
+    ) -> Optional[str]:
+        """Generate a context-aware question based on the original question.
+
+        Args:
+            question: The original user question.
+            verdict: The grounding check verdict.
+
+        Returns:
+            A context-specific follow-up question, or None.
+        """
+        # Extract key terms from the question for personalized follow-up
+        question_lower = question.lower()
+
+        # Check for common question patterns and generate relevant follow-ups
+        if "언제" in question or "시간" in question:
+            if verdict == Verdict.INSUFFICIENT:
+                return "특정 요일이나 기간에 대해 질문하시는 건가요?"
+
+        if "어떻게" in question or "방법" in question:
+            if verdict == Verdict.INSUFFICIENT:
+                return "어떤 상황에서의 방법을 알고 싶으신가요?"
+
+        if "누가" in question or "담당" in question:
+            if verdict == Verdict.INSUFFICIENT:
+                return "어떤 업무나 상황의 담당자를 찾으시는 건가요?"
+
+        if "왜" in question or "이유" in question:
+            if verdict == Verdict.INSUFFICIENT:
+                return "특정 정책이나 절차의 이유를 알고 싶으신가요?"
+
+        if verdict == Verdict.NOT_FOUND:
+            return f"'{self._extract_key_term(question)}'에 대해 다른 표현으로 검색해 볼까요?"
+
+        return None
+
+    def _generate_citation_questions(
+        self,
+        citations: list[Citation],
+        verdict: Verdict,
+    ) -> list[str]:
+        """Generate questions based on available citations.
+
+        Args:
+            citations: Available citations.
+            verdict: The grounding check verdict.
+
+        Returns:
+            List of citation-based follow-up questions.
+        """
+        questions = []
+
+        if not citations:
+            return questions
+
+        # If there are low-score citations, ask if they want related info
+        low_score_citations = [c for c in citations if c.score < 0.6]
+        if low_score_citations and verdict == Verdict.INSUFFICIENT:
+            doc_titles = set(c.title for c in low_score_citations[:2])
+            if doc_titles:
+                titles_str = ", ".join(f"'{t}'" for t in doc_titles)
+                questions.append(f"{titles_str} 문서에서 관련 정보를 찾아볼까요?")
+
+        # If there are conflicting citations, ask for clarification
+        if verdict == Verdict.CONFLICT and len(citations) > 1:
+            # Get unique document titles
+            doc_titles = list(set(c.title for c in citations[:3]))
+            if len(doc_titles) > 1:
+                questions.append(
+                    f"'{doc_titles[0]}'과 '{doc_titles[1]}' 중 어느 문서의 정보가 필요하신가요?"
+                )
+
+        return questions
+
+    @staticmethod
+    def _extract_key_term(question: str) -> str:
+        """Extract the main keyword from a question.
+
+        This is a simplified extraction that removes common question words.
+
+        Args:
+            question: The user's question.
+
+        Returns:
+            Extracted key term or the first few words.
+        """
+        # Remove common question prefixes and suffixes
+        stop_words = [
+            "이", "가", "은", "는", "을", "를", "에", "의", "로", "으로",
+            "어떻게", "무엇", "언제", "어디", "누가", "왜",
+            "하나요", "인가요", "있나요", "할까요", "될까요",
+            "해주세요", "알려주세요", "설명해주세요",
+        ]
+
+        words = question.split()
+        key_words = []
+
+        for word in words:
+            is_stop = False
+            for stop in stop_words:
+                if word.endswith(stop) or word == stop:
+                    # Keep the word if it's meaningful after removing stop word
+                    cleaned = word.replace(stop, "").strip()
+                    if cleaned and len(cleaned) > 1:
+                        key_words.append(cleaned)
+                    is_stop = True
+                    break
+            if not is_stop and len(word) > 1:
+                key_words.append(word)
+
+        if key_words:
+            return " ".join(key_words[:3])
+
+        # Fallback: return first few words
+        return " ".join(words[:3]) if words else question

--- a/agents/store_ops_agent/app/core/grounding_checker.py
+++ b/agents/store_ops_agent/app/core/grounding_checker.py
@@ -1,0 +1,361 @@
+"""Grounding checker for evidence validation and fail-safe logic.
+
+This module implements the fail-safe policy that prevents definitive answers
+when evidence is insufficient or conflicting.
+"""
+
+from dataclasses import dataclass, field
+from datetime import datetime
+from typing import Optional
+
+from app.models.schemas import Citation, ConflictInfo, Verdict
+
+
+@dataclass
+class GroundingResult:
+    """Result of grounding check."""
+
+    verdict: Verdict
+    is_sufficient: bool
+    conflict_info: Optional[ConflictInfo] = None
+    recommended_citation: Optional[Citation] = None
+    withheld_reason: Optional[str] = None
+
+
+class GroundingChecker:
+    """Validates evidence sufficiency and detects conflicts.
+
+    Implements the fail-safe policy:
+    - Prevents definitive answers when evidence is insufficient
+    - Detects and handles conflicting information
+    - Recommends the most recent/authoritative source when conflicts exist
+    """
+
+    def __init__(
+        self,
+        min_citations: int = 1,
+        min_score_threshold: float = 0.6,
+        conflict_score_diff_threshold: float = 0.15,
+    ) -> None:
+        """Initialize the grounding checker.
+
+        Args:
+            min_citations: Minimum number of citations required for a definitive answer.
+            min_score_threshold: Minimum relevance score for citations to be considered valid.
+            conflict_score_diff_threshold: Score difference threshold below which
+                citations may be considered conflicting.
+        """
+        self.min_citations = min_citations
+        self.min_score_threshold = min_score_threshold
+        self.conflict_score_diff_threshold = conflict_score_diff_threshold
+
+    def check(
+        self,
+        citations: list[Citation],
+        question: str,
+    ) -> GroundingResult:
+        """Perform grounding check on citations.
+
+        Args:
+            citations: List of retrieved citations.
+            question: The user's question for context.
+
+        Returns:
+            GroundingResult with verdict and related information.
+        """
+        # Case 1: No citations found
+        if not citations:
+            return GroundingResult(
+                verdict=Verdict.NOT_FOUND,
+                is_sufficient=False,
+                withheld_reason="검색 결과가 없습니다. 다른 키워드로 질문해 주세요.",
+            )
+
+        # Filter citations by minimum score
+        valid_citations = [c for c in citations if c.score >= self.min_score_threshold]
+
+        # Case 2: No citations meet the threshold
+        if not valid_citations:
+            return GroundingResult(
+                verdict=Verdict.INSUFFICIENT,
+                is_sufficient=False,
+                withheld_reason="관련 문서가 있으나 신뢰도가 충분하지 않습니다.",
+            )
+
+        # Case 3: Check for conflicts
+        conflict_result = self._detect_conflicts(valid_citations)
+        if conflict_result:
+            return conflict_result
+
+        # Case 4: Insufficient citations
+        if len(valid_citations) < self.min_citations:
+            return GroundingResult(
+                verdict=Verdict.INSUFFICIENT,
+                is_sufficient=False,
+                withheld_reason="현재 문서로는 확답을 드리기 어렵습니다.",
+            )
+
+        # Case 5: Partial answer (some but not enough high-quality citations)
+        high_score_citations = [c for c in valid_citations if c.score >= 0.8]
+        if not high_score_citations and len(valid_citations) >= self.min_citations:
+            return GroundingResult(
+                verdict=Verdict.PARTIAL,
+                is_sufficient=True,  # Can still provide answer, but partial
+            )
+
+        # Case 6: Sufficient evidence
+        return GroundingResult(
+            verdict=Verdict.ANSWERED,
+            is_sufficient=True,
+        )
+
+    def _detect_conflicts(
+        self,
+        citations: list[Citation],
+    ) -> Optional[GroundingResult]:
+        """Detect conflicting information in citations.
+
+        Conflicts are detected when citations have similar scores but may
+        contain contradictory information. In real implementation, this would
+        use semantic analysis.
+
+        Args:
+            citations: List of valid citations to check.
+
+        Returns:
+            GroundingResult if conflict detected, None otherwise.
+        """
+        if len(citations) < 2:
+            return None
+
+        # Sort by score descending
+        sorted_citations = sorted(citations, key=lambda c: c.score, reverse=True)
+
+        # Check for potential conflicts between top citations
+        # In a real implementation, this would compare semantic content
+        top_citation = sorted_citations[0]
+
+        potential_conflicts = []
+        for citation in sorted_citations[1:]:
+            score_diff = top_citation.score - citation.score
+            if score_diff <= self.conflict_score_diff_threshold:
+                # Citations with similar scores might conflict
+                # Check if they have different effective dates or versions
+                if self._may_conflict(top_citation, citation):
+                    potential_conflicts.append(citation)
+
+        if potential_conflicts:
+            conflicting_ids = [top_citation.doc_id] + [c.doc_id for c in potential_conflicts]
+
+            # Resolve by effective_date/version
+            recommended, resolution_basis = self._resolve_conflict(
+                [top_citation] + potential_conflicts
+            )
+
+            return GroundingResult(
+                verdict=Verdict.CONFLICT,
+                is_sufficient=False,
+                conflict_info=ConflictInfo(
+                    conflicting_citations=conflicting_ids,
+                    resolution_basis=resolution_basis,
+                    recommended_citation_id=recommended.doc_id if recommended else None,
+                ),
+                recommended_citation=recommended,
+                withheld_reason=(
+                    "문서 간 상충되는 정보가 발견되었습니다. "
+                    f"{resolution_basis} 기준으로 최신 정보를 안내해 드립니다."
+                    if resolution_basis
+                    else "문서 간 상충되는 정보가 발견되었습니다."
+                ),
+            )
+
+        return None
+
+    def _may_conflict(
+        self,
+        citation1: Citation,
+        citation2: Citation,
+    ) -> bool:
+        """Check if two citations may contain conflicting information.
+
+        This is a simplified check based on different document IDs and dates.
+        In a real implementation, this would use semantic comparison.
+
+        Args:
+            citation1: First citation.
+            citation2: Second citation.
+
+        Returns:
+            True if citations may conflict.
+        """
+        # Different documents with different dates/versions may conflict
+        if citation1.doc_id == citation2.doc_id:
+            return False
+
+        # Check if they have different effective dates or versions
+        has_different_dates = (
+            citation1.effective_date != citation2.effective_date
+            and citation1.effective_date is not None
+            and citation2.effective_date is not None
+        )
+
+        has_different_versions = (
+            citation1.version != citation2.version
+            and citation1.version is not None
+            and citation2.version is not None
+        )
+
+        return has_different_dates or has_different_versions
+
+    def _resolve_conflict(
+        self,
+        conflicting_citations: list[Citation],
+    ) -> tuple[Optional[Citation], Optional[str]]:
+        """Resolve conflict by selecting the most authoritative citation.
+
+        Priority:
+        1. Most recent effective_date
+        2. Most recent version
+        3. Highest score (fallback)
+
+        Args:
+            conflicting_citations: List of conflicting citations.
+
+        Returns:
+            Tuple of (recommended citation, resolution basis).
+        """
+        if not conflicting_citations:
+            return None, None
+
+        # Try to resolve by effective_date
+        citations_with_dates = [
+            c for c in conflicting_citations if c.effective_date is not None
+        ]
+
+        if citations_with_dates:
+            # Sort by effective_date descending
+            sorted_by_date = sorted(
+                citations_with_dates,
+                key=lambda c: self._parse_date(c.effective_date),
+                reverse=True,
+            )
+            return sorted_by_date[0], "effective_date"
+
+        # Try to resolve by version
+        citations_with_versions = [
+            c for c in conflicting_citations if c.version is not None
+        ]
+
+        if citations_with_versions:
+            # Sort by version descending (assumes semantic versioning or simple comparison)
+            sorted_by_version = sorted(
+                citations_with_versions,
+                key=lambda c: c.version or "",
+                reverse=True,
+            )
+            return sorted_by_version[0], "version"
+
+        # Fallback to highest score
+        sorted_by_score = sorted(
+            conflicting_citations,
+            key=lambda c: c.score,
+            reverse=True,
+        )
+        return sorted_by_score[0], "relevance_score"
+
+    @staticmethod
+    def _parse_date(date_str: Optional[str]) -> datetime:
+        """Parse date string to datetime for comparison.
+
+        Args:
+            date_str: Date string in various formats.
+
+        Returns:
+            Parsed datetime, or minimum datetime if parsing fails.
+        """
+        if not date_str:
+            return datetime.min
+
+        # Try common date formats
+        formats = [
+            "%Y-%m-%d",
+            "%Y/%m/%d",
+            "%d-%m-%Y",
+            "%d/%m/%Y",
+            "%Y-%m-%dT%H:%M:%S",
+            "%Y-%m-%dT%H:%M:%SZ",
+        ]
+
+        for fmt in formats:
+            try:
+                return datetime.strptime(date_str, fmt)
+            except ValueError:
+                continue
+
+        return datetime.min
+
+
+class FailSafePolicy:
+    """Implements fail-safe policy for answer generation.
+
+    Ensures that definitive answers are never provided when evidence
+    is insufficient or conflicting.
+    """
+
+    # Messages for different scenarios
+    INSUFFICIENT_EVIDENCE_MSG = (
+        "현재 문서로는 확답을 드리기 어렵습니다. "
+        "질문을 더 구체적으로 해주시거나, 다른 키워드로 검색해 보시기 바랍니다."
+    )
+
+    NO_RESULTS_MSG = (
+        "관련 문서를 찾을 수 없습니다. "
+        "다른 표현이나 키워드로 질문해 주세요."
+    )
+
+    CONFLICT_MSG = (
+        "문서 간 상충되는 정보가 발견되었습니다. "
+        "아래에 최신 정보를 기준으로 안내해 드리지만, 담당자에게 확인을 권장합니다."
+    )
+
+    @staticmethod
+    def should_withhold_answer(grounding_result: GroundingResult) -> bool:
+        """Determine if an answer should be withheld based on grounding result.
+
+        Args:
+            grounding_result: Result from grounding check.
+
+        Returns:
+            True if answer should be withheld.
+        """
+        # Always withhold for insufficient evidence or no results
+        if grounding_result.verdict in (Verdict.NOT_FOUND, Verdict.INSUFFICIENT):
+            return True
+
+        # For conflicts, we provide a cautious answer with the recommended citation
+        # but mark it as needing verification
+        return False
+
+    @staticmethod
+    def get_withheld_message(grounding_result: GroundingResult) -> str:
+        """Get appropriate message when answer is withheld.
+
+        Args:
+            grounding_result: Result from grounding check.
+
+        Returns:
+            User-friendly message explaining why answer is withheld.
+        """
+        if grounding_result.withheld_reason:
+            return grounding_result.withheld_reason
+
+        if grounding_result.verdict == Verdict.NOT_FOUND:
+            return FailSafePolicy.NO_RESULTS_MSG
+
+        if grounding_result.verdict == Verdict.INSUFFICIENT:
+            return FailSafePolicy.INSUFFICIENT_EVIDENCE_MSG
+
+        if grounding_result.verdict == Verdict.CONFLICT:
+            return FailSafePolicy.CONFLICT_MSG
+
+        return "답변을 생성할 수 없습니다."

--- a/agents/store_ops_agent/app/core/tracing.py
+++ b/agents/store_ops_agent/app/core/tracing.py
@@ -135,6 +135,8 @@ class MetricsCollector:
             Verdict.ANSWERED: 0,
             Verdict.PARTIAL: 0,
             Verdict.NOT_FOUND: 0,
+            Verdict.INSUFFICIENT: 0,
+            Verdict.CONFLICT: 0,
         }
 
     def record(self, meta: Meta) -> None:

--- a/agents/store_ops_agent/app/models/__init__.py
+++ b/agents/store_ops_agent/app/models/__init__.py
@@ -3,6 +3,7 @@
 from app.models.schemas import (
     AnswerResponse,
     Citation,
+    ConflictInfo,
     Meta,
     QuestionRequest,
     Verdict,
@@ -11,6 +12,7 @@ from app.models.schemas import (
 __all__ = [
     "AnswerResponse",
     "Citation",
+    "ConflictInfo",
     "Meta",
     "QuestionRequest",
     "Verdict",

--- a/agents/store_ops_agent/tests/test_answer_orchestrator.py
+++ b/agents/store_ops_agent/tests/test_answer_orchestrator.py
@@ -1,0 +1,379 @@
+"""Tests for answer orchestrator with retry logic."""
+
+import pytest
+
+from app.core.answer_orchestrator import AnswerOrchestrator, OrchestratorConfig
+from app.core.tracing import RequestTracer
+from app.models.schemas import Citation, Verdict
+
+
+class MockRetriever:
+    """Mock retriever for testing."""
+
+    def __init__(self, citations_sequence: list[list[Citation]]) -> None:
+        """Initialize with a sequence of citation lists to return.
+
+        Args:
+            citations_sequence: List of citation lists, one per retrieval call.
+        """
+        self.citations_sequence = citations_sequence
+        self.call_count = 0
+
+    async def retrieve(self, query: str, topk: int) -> list[Citation]:
+        """Return the next set of citations in the sequence."""
+        if self.call_count < len(self.citations_sequence):
+            result = self.citations_sequence[self.call_count]
+            self.call_count += 1
+            return result
+        return []
+
+
+@pytest.fixture
+def config() -> OrchestratorConfig:
+    """Create orchestrator config."""
+    return OrchestratorConfig(
+        max_retrieval_attempts=2,
+        min_citations=1,
+        min_score_threshold=0.6,
+        max_followup_questions=3,
+    )
+
+
+@pytest.fixture
+def orchestrator(config: OrchestratorConfig) -> AnswerOrchestrator:
+    """Create answer orchestrator."""
+    return AnswerOrchestrator(config=config)
+
+
+@pytest.fixture
+def high_score_citation() -> Citation:
+    """Create a high-score citation."""
+    return Citation(
+        doc_id="doc_001",
+        title="매장 운영 매뉴얼",
+        chunk_id="chunk_001",
+        snippet="영업시간은 오전 9시부터 오후 10시까지입니다.",
+        score=0.92,
+    )
+
+
+@pytest.fixture
+def low_score_citation() -> Citation:
+    """Create a low-score citation."""
+    return Citation(
+        doc_id="doc_002",
+        title="직원 근무 규정",
+        chunk_id="chunk_002",
+        snippet="근무 관련 정보입니다.",
+        score=0.45,
+    )
+
+
+class TestAnswerOrchestrator:
+    """Tests for AnswerOrchestrator class."""
+
+    @pytest.mark.asyncio
+    async def test_successful_retrieval_no_retry(
+        self,
+        orchestrator: AnswerOrchestrator,
+        high_score_citation: Citation,
+    ) -> None:
+        """Test successful retrieval without retry."""
+        tracer = RequestTracer()
+        retriever = MockRetriever([[high_score_citation]])
+
+        response = await orchestrator.process_question(
+            question="영업시간이 어떻게 되나요?",
+            topk=5,
+            tracer=tracer,
+            retriever=retriever,
+        )
+
+        assert response.meta.verdict == Verdict.ANSWERED
+        assert response.withheld is False
+        assert retriever.call_count == 1
+        assert tracer.retrieval_attempts == 1
+
+    @pytest.mark.asyncio
+    async def test_retry_on_no_results(
+        self,
+        orchestrator: AnswerOrchestrator,
+        high_score_citation: Citation,
+    ) -> None:
+        """Test retry when first retrieval returns no results."""
+        tracer = RequestTracer()
+        # First call returns empty, second returns results
+        retriever = MockRetriever([[], [high_score_citation]])
+
+        response = await orchestrator.process_question(
+            question="영업시간이 어떻게 되나요?",
+            topk=5,
+            tracer=tracer,
+            retriever=retriever,
+        )
+
+        assert response.meta.verdict == Verdict.ANSWERED
+        assert response.withheld is False
+        assert retriever.call_count == 2
+        assert tracer.retrieval_attempts == 2
+
+    @pytest.mark.asyncio
+    async def test_retry_on_low_score_results(
+        self,
+        orchestrator: AnswerOrchestrator,
+        low_score_citation: Citation,
+        high_score_citation: Citation,
+    ) -> None:
+        """Test retry when first retrieval returns low-score results."""
+        tracer = RequestTracer()
+        # First call returns low score, second returns high score
+        retriever = MockRetriever([[low_score_citation], [high_score_citation]])
+
+        response = await orchestrator.process_question(
+            question="영업시간이 어떻게 되나요?",
+            topk=5,
+            tracer=tracer,
+            retriever=retriever,
+        )
+
+        assert response.meta.verdict == Verdict.ANSWERED
+        assert retriever.call_count == 2
+
+    @pytest.mark.asyncio
+    async def test_max_one_retry(
+        self,
+        orchestrator: AnswerOrchestrator,
+    ) -> None:
+        """Test that retry is limited to max 1 (total 2 attempts)."""
+        tracer = RequestTracer()
+        # All calls return empty - should only try twice
+        retriever = MockRetriever([[], [], []])
+
+        response = await orchestrator.process_question(
+            question="영업시간이 어떻게 되나요?",
+            topk=5,
+            tracer=tracer,
+            retriever=retriever,
+        )
+
+        assert response.meta.verdict == Verdict.NOT_FOUND
+        assert response.withheld is True
+        assert retriever.call_count == 2  # Max 2 attempts
+        assert tracer.retrieval_attempts == 2
+
+    @pytest.mark.asyncio
+    async def test_withheld_answer_for_insufficient(
+        self,
+        orchestrator: AnswerOrchestrator,
+        low_score_citation: Citation,
+    ) -> None:
+        """Test answer is withheld for insufficient evidence."""
+        tracer = RequestTracer()
+        retriever = MockRetriever([[low_score_citation], [low_score_citation]])
+
+        response = await orchestrator.process_question(
+            question="영업시간이 어떻게 되나요?",
+            topk=5,
+            tracer=tracer,
+            retriever=retriever,
+        )
+
+        assert response.meta.verdict == Verdict.INSUFFICIENT
+        assert response.withheld is True
+        assert response.withheld_reason is not None
+
+    @pytest.mark.asyncio
+    async def test_follow_up_questions_generated(
+        self,
+        orchestrator: AnswerOrchestrator,
+    ) -> None:
+        """Test that follow-up questions are generated."""
+        tracer = RequestTracer()
+        retriever = MockRetriever([[]])
+
+        response = await orchestrator.process_question(
+            question="영업시간이 어떻게 되나요?",
+            topk=5,
+            tracer=tracer,
+            retriever=retriever,
+        )
+
+        assert response.follow_up_questions is not None
+        assert len(response.follow_up_questions) > 0
+
+    @pytest.mark.asyncio
+    async def test_conflict_handling(
+        self,
+        orchestrator: AnswerOrchestrator,
+    ) -> None:
+        """Test handling of conflicting citations."""
+        tracer = RequestTracer()
+
+        conflicting_citations = [
+            Citation(
+                doc_id="doc_001",
+                title="매뉴얼 2024",
+                chunk_id="chunk_001",
+                snippet="영업시간: 9시-22시",
+                score=0.90,
+                effective_date="2024-01-01",
+            ),
+            Citation(
+                doc_id="doc_002",
+                title="매뉴얼 2023",
+                chunk_id="chunk_002",
+                snippet="영업시간: 10시-21시",
+                score=0.88,
+                effective_date="2023-01-01",
+            ),
+        ]
+        retriever = MockRetriever([conflicting_citations])
+
+        response = await orchestrator.process_question(
+            question="영업시간이 어떻게 되나요?",
+            topk=5,
+            tracer=tracer,
+            retriever=retriever,
+        )
+
+        assert response.meta.verdict == Verdict.CONFLICT
+        assert response.meta.conflict_info is not None
+        assert response.withheld is False  # Conflict provides cautious answer
+        assert "상충" in response.answer
+
+    @pytest.mark.asyncio
+    async def test_no_retry_for_conflict(
+        self,
+        orchestrator: AnswerOrchestrator,
+    ) -> None:
+        """Test that retry is not performed for conflict verdict."""
+        tracer = RequestTracer()
+
+        conflicting_citations = [
+            Citation(
+                doc_id="doc_001",
+                title="문서 A",
+                chunk_id="chunk_001",
+                snippet="정보 A",
+                score=0.85,
+                effective_date="2024-01-01",
+            ),
+            Citation(
+                doc_id="doc_002",
+                title="문서 B",
+                chunk_id="chunk_002",
+                snippet="정보 B",
+                score=0.84,
+                effective_date="2023-01-01",
+            ),
+        ]
+        # Second set would be returned if retry happened
+        other_citations = [
+            Citation(
+                doc_id="doc_003",
+                title="다른 문서",
+                chunk_id="chunk_003",
+                snippet="다른 정보",
+                score=0.95,
+            ),
+        ]
+        retriever = MockRetriever([conflicting_citations, other_citations])
+
+        response = await orchestrator.process_question(
+            question="질문",
+            topk=5,
+            tracer=tracer,
+            retriever=retriever,
+        )
+
+        # Should not retry for conflict - only 1 call
+        assert retriever.call_count == 1
+        assert response.meta.verdict == Verdict.CONFLICT
+
+
+class TestOrchestratorConfig:
+    """Tests for OrchestratorConfig."""
+
+    def test_default_config(self) -> None:
+        """Test default configuration values."""
+        config = OrchestratorConfig()
+
+        assert config.max_retrieval_attempts == 2
+        assert config.min_citations == 1
+        assert config.min_score_threshold == 0.6
+        assert config.max_followup_questions == 3
+
+    def test_custom_config(self) -> None:
+        """Test custom configuration."""
+        config = OrchestratorConfig(
+            max_retrieval_attempts=3,
+            min_citations=2,
+            min_score_threshold=0.7,
+            max_followup_questions=5,
+        )
+
+        assert config.max_retrieval_attempts == 3
+        assert config.min_citations == 2
+        assert config.min_score_threshold == 0.7
+        assert config.max_followup_questions == 5
+
+
+class TestAnswerGeneration:
+    """Tests for answer generation methods."""
+
+    def test_default_answer_generation(
+        self,
+        orchestrator: AnswerOrchestrator,
+        high_score_citation: Citation,
+    ) -> None:
+        """Test default answer generation."""
+        answer = orchestrator._generate_default_answer(
+            question="영업시간이 어떻게 되나요?",
+            citations=[high_score_citation],
+        )
+
+        assert "영업시간" in answer
+        assert high_score_citation.title in answer
+
+    def test_default_answer_no_citations(
+        self,
+        orchestrator: AnswerOrchestrator,
+    ) -> None:
+        """Test default answer with no citations."""
+        answer = orchestrator._generate_default_answer(
+            question="영업시간이 어떻게 되나요?",
+            citations=[],
+        )
+
+        assert "찾을 수 없습니다" in answer
+
+    def test_conflict_answer_generation(
+        self,
+        orchestrator: AnswerOrchestrator,
+    ) -> None:
+        """Test conflict answer generation."""
+        from app.models.schemas import ConflictInfo
+
+        citation = Citation(
+            doc_id="doc_001",
+            title="최신 매뉴얼",
+            chunk_id="chunk_001",
+            snippet="최신 정보입니다.",
+            score=0.90,
+            effective_date="2024-01-01",
+        )
+        conflict_info = ConflictInfo(
+            conflicting_citations=["doc_001", "doc_002"],
+            resolution_basis="effective_date",
+            recommended_citation_id="doc_001",
+        )
+
+        answer = orchestrator._generate_conflict_answer(
+            question="질문",
+            recommended_citation=citation,
+            conflict_info=conflict_info,
+        )
+
+        assert "상충" in answer
+        assert citation.title in answer
+        assert "2024-01-01" in answer

--- a/agents/store_ops_agent/tests/test_followup_generator.py
+++ b/agents/store_ops_agent/tests/test_followup_generator.py
@@ -1,0 +1,209 @@
+"""Tests for follow-up question generator."""
+
+import pytest
+
+from app.core.followup_generator import FollowUpGenerator
+from app.models.schemas import Citation, Verdict
+
+
+@pytest.fixture
+def generator() -> FollowUpGenerator:
+    """Create a follow-up generator instance."""
+    return FollowUpGenerator(max_questions=3)
+
+
+@pytest.fixture
+def sample_citations() -> list[Citation]:
+    """Create sample citations for testing."""
+    return [
+        Citation(
+            doc_id="doc_001",
+            title="매장 운영 매뉴얼",
+            chunk_id="chunk_001",
+            snippet="영업시간 관련 정보",
+            score=0.85,
+        ),
+        Citation(
+            doc_id="doc_002",
+            title="직원 근무 규정",
+            chunk_id="chunk_002",
+            snippet="근무 시간 정보",
+            score=0.55,
+        ),
+    ]
+
+
+class TestFollowUpGenerator:
+    """Tests for FollowUpGenerator class."""
+
+    def test_generates_questions_for_not_found(
+        self,
+        generator: FollowUpGenerator,
+    ) -> None:
+        """Test generating questions for NOT_FOUND verdict."""
+        questions = generator.generate(
+            verdict=Verdict.NOT_FOUND,
+            question="영업시간이 어떻게 되나요?",
+        )
+
+        assert len(questions) > 0
+        assert len(questions) <= 3
+
+    def test_generates_questions_for_insufficient(
+        self,
+        generator: FollowUpGenerator,
+    ) -> None:
+        """Test generating questions for INSUFFICIENT verdict."""
+        questions = generator.generate(
+            verdict=Verdict.INSUFFICIENT,
+            question="환불 규정이 뭔가요?",
+        )
+
+        assert len(questions) > 0
+        assert len(questions) <= 3
+
+    def test_generates_questions_for_conflict(
+        self,
+        generator: FollowUpGenerator,
+        sample_citations: list[Citation],
+    ) -> None:
+        """Test generating questions for CONFLICT verdict."""
+        questions = generator.generate(
+            verdict=Verdict.CONFLICT,
+            question="영업시간이 어떻게 되나요?",
+            citations=sample_citations,
+        )
+
+        assert len(questions) > 0
+        assert len(questions) <= 3
+
+    def test_respects_max_questions_limit(
+        self,
+        generator: FollowUpGenerator,
+    ) -> None:
+        """Test that generator respects max_questions limit."""
+        questions = generator.generate(
+            verdict=Verdict.NOT_FOUND,
+            question="영업시간이 어떻게 되나요?",
+        )
+
+        assert len(questions) <= generator.max_questions
+
+    def test_context_question_for_time_related(
+        self,
+        generator: FollowUpGenerator,
+    ) -> None:
+        """Test context-specific question for time-related queries."""
+        questions = generator.generate(
+            verdict=Verdict.INSUFFICIENT,
+            question="언제 문을 여나요?",
+        )
+
+        # Should include a time-specific follow-up
+        assert any("요일" in q or "기간" in q for q in questions)
+
+    def test_context_question_for_method_related(
+        self,
+        generator: FollowUpGenerator,
+    ) -> None:
+        """Test context-specific question for method-related queries."""
+        questions = generator.generate(
+            verdict=Verdict.INSUFFICIENT,
+            question="어떻게 신청하나요?",
+        )
+
+        # Should include a method-specific follow-up
+        assert any("상황" in q for q in questions)
+
+    def test_citation_based_questions_for_conflict(
+        self,
+    ) -> None:
+        """Test that citation-based questions are generated for conflicts."""
+        generator = FollowUpGenerator(max_questions=5)
+        citations = [
+            Citation(
+                doc_id="doc_001",
+                title="매뉴얼 2024",
+                chunk_id="chunk_001",
+                snippet="정보 1",
+                score=0.85,
+            ),
+            Citation(
+                doc_id="doc_002",
+                title="매뉴얼 2023",
+                chunk_id="chunk_002",
+                snippet="정보 2",
+                score=0.83,
+            ),
+        ]
+
+        questions = generator.generate(
+            verdict=Verdict.CONFLICT,
+            question="영업시간이 어떻게 되나요?",
+            citations=citations,
+        )
+
+        # Should mention the conflicting documents
+        assert any("매뉴얼" in q for q in questions)
+
+    def test_no_duplicate_questions(
+        self,
+        generator: FollowUpGenerator,
+        sample_citations: list[Citation],
+    ) -> None:
+        """Test that generated questions are unique."""
+        questions = generator.generate(
+            verdict=Verdict.INSUFFICIENT,
+            question="영업시간이 어떻게 되나요?",
+            citations=sample_citations,
+        )
+
+        # All questions should be unique
+        assert len(questions) == len(set(questions))
+
+
+class TestKeyTermExtraction:
+    """Tests for key term extraction."""
+
+    def test_extracts_meaningful_terms(self) -> None:
+        """Test extraction of meaningful terms from question."""
+        result = FollowUpGenerator._extract_key_term("영업시간이 어떻게 되나요?")
+
+        # Should extract meaningful terms
+        assert "영업시간" in result or "영업" in result
+
+    def test_handles_empty_question(self) -> None:
+        """Test handling of empty question."""
+        result = FollowUpGenerator._extract_key_term("")
+
+        assert result == ""
+
+    def test_handles_single_word(self) -> None:
+        """Test handling of single word question."""
+        result = FollowUpGenerator._extract_key_term("환불")
+
+        assert "환불" in result
+
+    def test_removes_stop_words(self) -> None:
+        """Test removal of common stop words."""
+        result = FollowUpGenerator._extract_key_term("매장의 운영 방법을 알려주세요")
+
+        # Should remove stop words and keep meaningful terms
+        assert "알려주세요" not in result
+
+
+class TestPartialVerdictFollowUps:
+    """Tests for follow-up questions in PARTIAL verdict scenario."""
+
+    def test_generates_partial_followups(self) -> None:
+        """Test that partial verdict generates appropriate follow-ups."""
+        generator = FollowUpGenerator(max_questions=3)
+
+        questions = generator.generate(
+            verdict=Verdict.PARTIAL,
+            question="환불 규정이 뭔가요?",
+        )
+
+        # Should have follow-up questions for partial answers
+        assert len(questions) > 0
+        assert any("추가" in q or "다른" in q for q in questions)

--- a/agents/store_ops_agent/tests/test_grounding_checker.py
+++ b/agents/store_ops_agent/tests/test_grounding_checker.py
@@ -1,0 +1,301 @@
+"""Tests for grounding checker and fail-safe policy."""
+
+import pytest
+
+from app.core.grounding_checker import (
+    FailSafePolicy,
+    GroundingChecker,
+    GroundingResult,
+)
+from app.models.schemas import Citation, Verdict
+
+
+@pytest.fixture
+def grounding_checker() -> GroundingChecker:
+    """Create a grounding checker instance."""
+    return GroundingChecker(
+        min_citations=1,
+        min_score_threshold=0.6,
+        conflict_score_diff_threshold=0.15,
+    )
+
+
+@pytest.fixture
+def high_score_citation() -> Citation:
+    """Create a high-score citation."""
+    return Citation(
+        doc_id="doc_001",
+        title="매장 운영 매뉴얼",
+        chunk_id="chunk_001",
+        snippet="영업시간은 오전 9시부터 오후 10시까지입니다.",
+        score=0.92,
+        effective_date="2024-01-01",
+        version="v2.0",
+    )
+
+
+@pytest.fixture
+def low_score_citation() -> Citation:
+    """Create a low-score citation."""
+    return Citation(
+        doc_id="doc_002",
+        title="직원 근무 규정",
+        chunk_id="chunk_002",
+        snippet="근무 시간 관련 정보입니다.",
+        score=0.45,
+    )
+
+
+@pytest.fixture
+def conflicting_citation() -> Citation:
+    """Create a citation that conflicts with high_score_citation."""
+    return Citation(
+        doc_id="doc_003",
+        title="이전 매뉴얼",
+        chunk_id="chunk_003",
+        snippet="영업시간은 오전 10시부터 오후 9시까지입니다.",
+        score=0.90,
+        effective_date="2023-06-01",
+        version="v1.0",
+    )
+
+
+class TestGroundingChecker:
+    """Tests for GroundingChecker class."""
+
+    def test_no_citations_returns_not_found(
+        self,
+        grounding_checker: GroundingChecker,
+    ) -> None:
+        """Test that empty citations returns NOT_FOUND verdict."""
+        result = grounding_checker.check([], "영업시간이 어떻게 되나요?")
+
+        assert result.verdict == Verdict.NOT_FOUND
+        assert result.is_sufficient is False
+        assert result.withheld_reason is not None
+        assert "검색 결과가 없습니다" in result.withheld_reason
+
+    def test_low_score_citations_returns_insufficient(
+        self,
+        grounding_checker: GroundingChecker,
+        low_score_citation: Citation,
+    ) -> None:
+        """Test that only low-score citations returns INSUFFICIENT verdict."""
+        result = grounding_checker.check([low_score_citation], "영업시간이 어떻게 되나요?")
+
+        assert result.verdict == Verdict.INSUFFICIENT
+        assert result.is_sufficient is False
+
+    def test_high_score_citation_returns_answered(
+        self,
+        grounding_checker: GroundingChecker,
+        high_score_citation: Citation,
+    ) -> None:
+        """Test that high-score citation returns ANSWERED verdict."""
+        result = grounding_checker.check([high_score_citation], "영업시간이 어떻게 되나요?")
+
+        assert result.verdict == Verdict.ANSWERED
+        assert result.is_sufficient is True
+
+    def test_conflicting_citations_returns_conflict(
+        self,
+        grounding_checker: GroundingChecker,
+        high_score_citation: Citation,
+        conflicting_citation: Citation,
+    ) -> None:
+        """Test that conflicting citations returns CONFLICT verdict."""
+        citations = [high_score_citation, conflicting_citation]
+        result = grounding_checker.check(citations, "영업시간이 어떻게 되나요?")
+
+        assert result.verdict == Verdict.CONFLICT
+        assert result.is_sufficient is False
+        assert result.conflict_info is not None
+        assert len(result.conflict_info.conflicting_citations) >= 2
+        assert result.conflict_info.resolution_basis == "effective_date"
+        assert result.conflict_info.recommended_citation_id == high_score_citation.doc_id
+
+    def test_conflict_resolution_by_version(
+        self,
+        grounding_checker: GroundingChecker,
+    ) -> None:
+        """Test conflict resolution by version when dates are not available."""
+        citation1 = Citation(
+            doc_id="doc_a",
+            title="문서 A",
+            chunk_id="chunk_a",
+            snippet="정보 A",
+            score=0.85,
+            version="v2.0",
+        )
+        citation2 = Citation(
+            doc_id="doc_b",
+            title="문서 B",
+            chunk_id="chunk_b",
+            snippet="정보 B",
+            score=0.84,
+            version="v1.0",
+        )
+
+        result = grounding_checker.check([citation1, citation2], "질문")
+
+        assert result.verdict == Verdict.CONFLICT
+        assert result.conflict_info is not None
+        assert result.conflict_info.resolution_basis == "version"
+        assert result.conflict_info.recommended_citation_id == citation1.doc_id
+
+    def test_partial_verdict_for_medium_score_citations(
+        self,
+        grounding_checker: GroundingChecker,
+    ) -> None:
+        """Test PARTIAL verdict when citations are valid but not high quality."""
+        citation = Citation(
+            doc_id="doc_001",
+            title="문서",
+            chunk_id="chunk_001",
+            snippet="관련 정보",
+            score=0.65,  # Above threshold but below 0.8
+        )
+
+        result = grounding_checker.check([citation], "질문")
+
+        assert result.verdict == Verdict.PARTIAL
+        assert result.is_sufficient is True
+
+    def test_no_conflict_for_same_document(
+        self,
+        grounding_checker: GroundingChecker,
+    ) -> None:
+        """Test that citations from same document don't conflict."""
+        citation1 = Citation(
+            doc_id="doc_001",
+            title="문서",
+            chunk_id="chunk_001",
+            snippet="정보 1",
+            score=0.90,
+            effective_date="2024-01-01",
+        )
+        citation2 = Citation(
+            doc_id="doc_001",  # Same doc_id
+            title="문서",
+            chunk_id="chunk_002",
+            snippet="정보 2",
+            score=0.88,
+            effective_date="2023-01-01",
+        )
+
+        result = grounding_checker.check([citation1, citation2], "질문")
+
+        # Should not detect conflict for same document
+        assert result.verdict != Verdict.CONFLICT
+
+
+class TestFailSafePolicy:
+    """Tests for FailSafePolicy class."""
+
+    def test_should_withhold_for_not_found(self) -> None:
+        """Test that answer is withheld for NOT_FOUND verdict."""
+        result = GroundingResult(
+            verdict=Verdict.NOT_FOUND,
+            is_sufficient=False,
+        )
+
+        assert FailSafePolicy.should_withhold_answer(result) is True
+
+    def test_should_withhold_for_insufficient(self) -> None:
+        """Test that answer is withheld for INSUFFICIENT verdict."""
+        result = GroundingResult(
+            verdict=Verdict.INSUFFICIENT,
+            is_sufficient=False,
+        )
+
+        assert FailSafePolicy.should_withhold_answer(result) is True
+
+    def test_should_not_withhold_for_conflict(self) -> None:
+        """Test that answer is NOT withheld for CONFLICT (we provide cautious answer)."""
+        result = GroundingResult(
+            verdict=Verdict.CONFLICT,
+            is_sufficient=False,
+        )
+
+        assert FailSafePolicy.should_withhold_answer(result) is False
+
+    def test_should_not_withhold_for_answered(self) -> None:
+        """Test that answer is NOT withheld for ANSWERED verdict."""
+        result = GroundingResult(
+            verdict=Verdict.ANSWERED,
+            is_sufficient=True,
+        )
+
+        assert FailSafePolicy.should_withhold_answer(result) is False
+
+    def test_get_withheld_message_for_not_found(self) -> None:
+        """Test withheld message for NOT_FOUND verdict."""
+        result = GroundingResult(
+            verdict=Verdict.NOT_FOUND,
+            is_sufficient=False,
+        )
+
+        message = FailSafePolicy.get_withheld_message(result)
+
+        assert "관련 문서를 찾을 수 없습니다" in message
+
+    def test_get_withheld_message_for_insufficient(self) -> None:
+        """Test withheld message for INSUFFICIENT verdict."""
+        result = GroundingResult(
+            verdict=Verdict.INSUFFICIENT,
+            is_sufficient=False,
+        )
+
+        message = FailSafePolicy.get_withheld_message(result)
+
+        assert "확답" in message or "확인" in message
+
+    def test_get_withheld_message_uses_custom_reason(self) -> None:
+        """Test that custom withheld_reason is used when provided."""
+        custom_reason = "커스텀 메시지입니다."
+        result = GroundingResult(
+            verdict=Verdict.INSUFFICIENT,
+            is_sufficient=False,
+            withheld_reason=custom_reason,
+        )
+
+        message = FailSafePolicy.get_withheld_message(result)
+
+        assert message == custom_reason
+
+
+class TestGroundingCheckerDateParsing:
+    """Tests for date parsing in GroundingChecker."""
+
+    def test_parse_date_iso_format(self) -> None:
+        """Test parsing ISO date format."""
+        result = GroundingChecker._parse_date("2024-01-15")
+        assert result.year == 2024
+        assert result.month == 1
+        assert result.day == 15
+
+    def test_parse_date_slash_format(self) -> None:
+        """Test parsing slash date format."""
+        result = GroundingChecker._parse_date("2024/01/15")
+        assert result.year == 2024
+        assert result.month == 1
+        assert result.day == 15
+
+    def test_parse_date_iso_datetime(self) -> None:
+        """Test parsing ISO datetime format."""
+        result = GroundingChecker._parse_date("2024-01-15T10:30:00")
+        assert result.year == 2024
+
+    def test_parse_date_returns_min_for_invalid(self) -> None:
+        """Test that invalid date returns datetime.min."""
+        from datetime import datetime
+
+        result = GroundingChecker._parse_date("invalid-date")
+        assert result == datetime.min
+
+    def test_parse_date_returns_min_for_none(self) -> None:
+        """Test that None returns datetime.min."""
+        from datetime import datetime
+
+        result = GroundingChecker._parse_date(None)
+        assert result == datetime.min


### PR DESCRIPTION
## Summary
- 검색 결과가 불충분할 때 단정적 답변 대신 추가 질문(follow-up question) 제공
- 문서 간 상충되는 정보 감지 및 effective_date/version 기준 최신 우선 안내
- 재검색 최대 1회 제한으로 무한 루프 방지

## Changes
### 모델 확장
- `Verdict` enum: `INSUFFICIENT`, `CONFLICT` 추가
- `Citation` 모델: `effective_date`, `version` 필드 추가
- `ConflictInfo` 모델 신규 추가
- `AnswerResponse`: `withheld`, `withheld_reason` 필드 추가
- `Meta`: `conflict_info` 필드 추가

### 핵심 로직
- `GroundingChecker`: 근거 충분성 검증, 상충 감지, 날짜/버전 기반 해결
- `FailSafePolicy`: 단정 금지 정책 (INSUFFICIENT/NOT_FOUND 시 답변 보류)
- `FollowUpGenerator`: 상황별 맞춤 추가 질문 생성
- `AnswerOrchestrator`: 재검색 루프 제어 (max 2 attempts = 1 retry)

## Test plan
- [x] GroundingChecker 테스트 (19개 케이스)
- [x] FollowUpGenerator 테스트 (13개 케이스)
- [x] AnswerOrchestrator 테스트 (13개 케이스)
- [x] 기존 테스트 호환성 확인 (전체 98개 통과)

## Acceptance Criteria (from Jira)
- [x] 검색 결과 0건 시 follow-up question 제공
- [x] insufficient verdict 시 확답 불가 메시지 + 추가 질문
- [x] conflict verdict 시 상충 명시 + effective_date/version 기준 최신 우선
- [x] 재검색 최대 1회 후 답변 보류
- [x] meta.verdict에 insufficient/conflict 표시

## Related
- Jira: [STOR-3](https://lukasdeveloperacc.atlassian.net/browse/STOR-3)

🤖 Generated with [Claude Code](https://claude.com/claude-code)