### PR TITLE
[STOR-6] LangGraph Agent 그래프 구현

### DIFF
--- a/agents/store_ops_agent/app/agents/__init__.py
+++ b/agents/store_ops_agent/app/agents/__init__.py
@@ -1,1 +1,65 @@
-"""LangGraph agents package."""
+"""LangGraph agents package for StoreOps Agent.
+
+This package provides:
+- Agent state schema (AgentState, create_initial_state)
+- Graph workflow (run_agent, run_agent_with_streaming)
+- Individual nodes (parse_classify, retrieve, generate, grounding_check, finalize)
+"""
+
+from app.agents.graph import (
+    build_agent_graph,
+    get_agent_graph,
+    run_agent,
+    run_agent_with_streaming,
+)
+from app.agents.nodes import (
+    finalize_node,
+    generate_node,
+    grounding_check_node,
+    parse_classify_node,
+    retrieve_node,
+)
+from app.agents.nodes.retrieve import VectorStoreManager
+from app.agents.state import (
+    AgentCounters,
+    AgentFilters,
+    AgentMetrics,
+    AgentState,
+    DraftAnswer,
+    FinalResponse,
+    GroundingCheckResult,
+    GroundingVerdict,
+    Intent,
+    ParsedQuery,
+    RetrievalResult,
+    create_initial_state,
+)
+
+__all__ = [
+    # State types
+    "AgentState",
+    "AgentCounters",
+    "AgentFilters",
+    "AgentMetrics",
+    "DraftAnswer",
+    "FinalResponse",
+    "GroundingCheckResult",
+    "GroundingVerdict",
+    "Intent",
+    "ParsedQuery",
+    "RetrievalResult",
+    "create_initial_state",
+    # Graph
+    "build_agent_graph",
+    "get_agent_graph",
+    "run_agent",
+    "run_agent_with_streaming",
+    # Nodes
+    "parse_classify_node",
+    "retrieve_node",
+    "generate_node",
+    "grounding_check_node",
+    "finalize_node",
+    # Utils
+    "VectorStoreManager",
+]

--- a/agents/store_ops_agent/app/agents/graph.py
+++ b/agents/store_ops_agent/app/agents/graph.py
@@ -1,0 +1,223 @@
+"""LangGraph workflow definition for StoreOps Agent.
+
+This module defines the agent graph with:
+- Nodes: parse_classify -> retrieve -> generate -> grounding_check -> finalize
+- Conditional routing: retry retrieve if grounding insufficient and attempts < 2
+"""
+
+import logging
+from typing import Literal
+
+from langgraph.graph import END, START, StateGraph
+
+from app.agents.nodes import (
+    finalize_node,
+    generate_node,
+    grounding_check_node,
+    parse_classify_node,
+    retrieve_node,
+)
+from app.agents.state import (
+    AgentState,
+    GroundingVerdict,
+    create_initial_state,
+)
+
+logger = logging.getLogger(__name__)
+
+# Maximum retrieval attempts before giving up
+MAX_RETRIEVAL_ATTEMPTS = 2
+
+
+def should_retry_retrieval(state: AgentState) -> Literal["retrieve", "finalize"]:
+    """Determine whether to retry retrieval or proceed to finalize.
+
+    Routing logic:
+    - If grounding verdict is 'insufficient' AND retrieval_attempts < MAX:
+      -> retry retrieve with relaxed filters
+    - Otherwise:
+      -> proceed to finalize
+
+    Args:
+        state: Current agent state.
+
+    Returns:
+        Next node name: 'retrieve' or 'finalize'.
+    """
+    grounding = state.get("grounding")
+    counters = state.get("counters")
+
+    if grounding is None:
+        logger.warning("No grounding result, proceeding to finalize")
+        return "finalize"
+
+    # Check if we should retry
+    should_retry = (
+        grounding.verdict == GroundingVerdict.INSUFFICIENT
+        and grounding.recommended_action == "retry_retrieval"
+        and counters is not None
+        and counters.retrieval_attempts < MAX_RETRIEVAL_ATTEMPTS
+    )
+
+    if should_retry:
+        logger.info(
+            f"Retrying retrieval (attempt {counters.retrieval_attempts + 1}/{MAX_RETRIEVAL_ATTEMPTS})"
+        )
+        return "retrieve"
+
+    return "finalize"
+
+
+def build_agent_graph() -> StateGraph:
+    """Build the LangGraph workflow for StoreOps Agent.
+
+    Graph structure:
+    ```
+    START -> parse_classify -> retrieve -> generate -> grounding_check
+                                  ^                         |
+                                  |                         v
+                                  +---- (if insufficient) --+
+                                                            |
+                                                            v
+                                                        finalize -> END
+    ```
+
+    Returns:
+        Compiled StateGraph ready for execution.
+    """
+    # Create graph with state schema
+    graph_builder = StateGraph(AgentState)
+
+    # Add nodes
+    graph_builder.add_node("parse_classify", parse_classify_node)
+    graph_builder.add_node("retrieve", retrieve_node)
+    graph_builder.add_node("generate", generate_node)
+    graph_builder.add_node("grounding_check", grounding_check_node)
+    graph_builder.add_node("finalize", finalize_node)
+
+    # Add edges
+    graph_builder.add_edge(START, "parse_classify")
+    graph_builder.add_edge("parse_classify", "retrieve")
+    graph_builder.add_edge("retrieve", "generate")
+    graph_builder.add_edge("generate", "grounding_check")
+
+    # Conditional edge from grounding_check
+    graph_builder.add_conditional_edges(
+        "grounding_check",
+        should_retry_retrieval,
+        {
+            "retrieve": "retrieve",
+            "finalize": "finalize",
+        },
+    )
+
+    graph_builder.add_edge("finalize", END)
+
+    return graph_builder.compile()
+
+
+# Global compiled graph instance
+_agent_graph = None
+
+
+def get_agent_graph() -> StateGraph:
+    """Get or create the agent graph singleton.
+
+    Returns:
+        Compiled agent graph.
+    """
+    global _agent_graph
+    if _agent_graph is None:
+        _agent_graph = build_agent_graph()
+    return _agent_graph
+
+
+async def run_agent(
+    question: str,
+    trace_id: str,
+    topk: int = 8,
+    store_type: str | None = None,
+    category: str | None = None,
+    effective_date: str | None = None,
+    language: str | None = None,
+) -> AgentState:
+    """Run the agent workflow with a question.
+
+    Args:
+        question: User's question.
+        trace_id: Unique trace ID for the request.
+        topk: Number of documents to retrieve.
+        store_type: Optional store type filter.
+        category: Optional category filter.
+        effective_date: Optional effective date filter (YYYY-MM-DD).
+        language: Optional language filter.
+
+    Returns:
+        Final agent state with response.
+    """
+    # Create initial state
+    initial_state = create_initial_state(
+        question=question,
+        trace_id=trace_id,
+        topk=topk,
+        store_type=store_type,
+        category=category,
+        effective_date=effective_date,
+        language=language,
+    )
+
+    # Get compiled graph
+    graph = get_agent_graph()
+
+    # Run graph
+    logger.info(f"Starting agent run for trace_id={trace_id}")
+    final_state = await graph.ainvoke(initial_state)
+    logger.info(f"Agent run completed for trace_id={trace_id}")
+
+    return final_state
+
+
+async def run_agent_with_streaming(
+    question: str,
+    trace_id: str,
+    topk: int = 8,
+    store_type: str | None = None,
+    category: str | None = None,
+    effective_date: str | None = None,
+    language: str | None = None,
+):
+    """Run the agent workflow with streaming output.
+
+    Yields state updates as the graph executes.
+
+    Args:
+        question: User's question.
+        trace_id: Unique trace ID for the request.
+        topk: Number of documents to retrieve.
+        store_type: Optional store type filter.
+        category: Optional category filter.
+        effective_date: Optional effective date filter (YYYY-MM-DD).
+        language: Optional language filter.
+
+    Yields:
+        Tuples of (node_name, state_update) for each node execution.
+    """
+    # Create initial state
+    initial_state = create_initial_state(
+        question=question,
+        trace_id=trace_id,
+        topk=topk,
+        store_type=store_type,
+        category=category,
+        effective_date=effective_date,
+        language=language,
+    )
+
+    # Get compiled graph
+    graph = get_agent_graph()
+
+    # Stream graph execution
+    logger.info(f"Starting streaming agent run for trace_id={trace_id}")
+    async for chunk in graph.astream(initial_state, stream_mode="updates"):
+        yield chunk
+    logger.info(f"Streaming agent run completed for trace_id={trace_id}")

--- a/agents/store_ops_agent/app/agents/nodes/__init__.py
+++ b/agents/store_ops_agent/app/agents/nodes/__init__.py
@@ -1,0 +1,15 @@
+"""LangGraph nodes for StoreOps Agent."""
+
+from app.agents.nodes.parse_classify import parse_classify_node
+from app.agents.nodes.retrieve import retrieve_node
+from app.agents.nodes.generate import generate_node
+from app.agents.nodes.grounding_check import grounding_check_node
+from app.agents.nodes.finalize import finalize_node
+
+__all__ = [
+    "parse_classify_node",
+    "retrieve_node",
+    "generate_node",
+    "grounding_check_node",
+    "finalize_node",
+]

--- a/agents/store_ops_agent/app/agents/nodes/finalize.py
+++ b/agents/store_ops_agent/app/agents/nodes/finalize.py
@@ -1,0 +1,341 @@
+"""Finalize Node for StoreOps Agent.
+
+This node:
+1. Takes grounding check result and draft answer
+2. Constructs final response based on verdict
+3. Generates follow-up questions if evidence insufficient
+4. Returns final response with answer, citations, follow_up_question, meta
+"""
+
+import logging
+import time
+from typing import Any
+
+from langchain_openai import ChatOpenAI
+from pydantic import BaseModel, Field
+
+from app.agents.state import (
+    AgentState,
+    FinalResponse,
+    GroundingVerdict,
+)
+from app.models.schemas import Citation
+
+logger = logging.getLogger(__name__)
+
+
+class FollowUpQuestions(BaseModel):
+    """Schema for follow-up questions generation."""
+
+    questions: list[str] = Field(
+        min_length=1,
+        max_length=3,
+        description="1-3 follow-up questions to clarify the user's intent",
+    )
+    clarification_needed: str = Field(
+        description="Brief explanation of why clarification is needed"
+    )
+
+
+FOLLOWUP_SYSTEM_PROMPT = """You are a helpful assistant that generates follow-up questions when the original question cannot be fully answered.
+
+Your task:
+1. Generate 1-3 clarifying questions that would help provide a better answer
+2. Questions should be specific and actionable
+3. Write in Korean (한국어)
+
+Examples of good follow-up questions:
+- "어느 매장 유형(카페, 편의점 등)에 대해 알고 싶으신가요?"
+- "해당 정책이 적용되는 시점을 알려주시겠어요?"
+- "환불 사유가 어떻게 되나요?"
+
+Keep questions concise and relevant to the original question."""
+
+
+FOLLOWUP_USER_TEMPLATE = """원래 질문: {question}
+
+근거 부족 이유: {issues}
+
+위 질문에 대해 더 정확한 답변을 드리기 위한 추가 질문을 생성해주세요."""
+
+
+async def finalize_node(state: AgentState) -> dict[str, Any]:
+    """Finalize the response based on grounding check.
+
+    Args:
+        state: Current agent state with grounding result.
+
+    Returns:
+        Dictionary with final response.
+    """
+    start_time = time.time()
+
+    grounding = state.get("grounding")
+    draft = state.get("draft")
+    retrieval = state.get("retrieval")
+
+    # Handle missing data
+    if grounding is None or draft is None:
+        return _create_error_response(state, "Missing grounding or draft data")
+
+    # Get citations used in the answer
+    citations = _get_final_citations(
+        draft.citations_used,
+        retrieval.candidates if retrieval else [],
+    )
+
+    # Build response based on verdict
+    if grounding.verdict == GroundingVerdict.PASS:
+        final = await _create_success_response(draft, citations)
+    elif grounding.verdict == GroundingVerdict.INSUFFICIENT:
+        final = await _create_insufficient_response(state, draft, citations, grounding)
+    elif grounding.verdict == GroundingVerdict.CONFLICT:
+        final = await _create_conflict_response(state, draft, citations, grounding)
+    elif grounding.verdict == GroundingVerdict.OFF_TOPIC:
+        final = _create_off_topic_response()
+    else:
+        final = await _create_insufficient_response(state, draft, citations, grounding)
+
+    latency_ms = (time.time() - start_time) * 1000
+    logger.info(
+        f"Finalize completed: withheld={final.withheld}, "
+        f"citations={len(final.citations)}, latency={latency_ms:.1f}ms"
+    )
+
+    # Calculate total latency
+    current_metrics = state.get("metrics")
+    if current_metrics:
+        current_metrics.total_latency_ms = (
+            current_metrics.parse_latency_ms
+            + current_metrics.retrieve_latency_ms
+            + current_metrics.generate_latency_ms
+            + current_metrics.grounding_latency_ms
+            + latency_ms
+        )
+
+    return {
+        "final": final,
+        "metrics": current_metrics,
+    }
+
+
+def _get_final_citations(
+    citation_ids: list[str], candidates: list[Citation]
+) -> list[Citation]:
+    """Get final Citation objects for response.
+
+    Args:
+        citation_ids: List of chunk_ids used.
+        candidates: All candidates.
+
+    Returns:
+        List of Citation objects.
+    """
+    if not candidates:
+        return []
+
+    id_to_citation = {c.chunk_id: c for c in candidates}
+    return [id_to_citation[cid] for cid in citation_ids if cid in id_to_citation]
+
+
+async def _create_success_response(
+    draft: Any, citations: list[Citation]
+) -> FinalResponse:
+    """Create successful response with grounded answer.
+
+    Args:
+        draft: Draft answer.
+        citations: Supporting citations.
+
+    Returns:
+        Final response.
+    """
+    return FinalResponse(
+        answer=draft.content,
+        citations=citations,
+        follow_up_question=None,
+        withheld=False,
+        withheld_reason=None,
+    )
+
+
+async def _create_insufficient_response(
+    state: AgentState,
+    draft: Any,
+    citations: list[Citation],
+    grounding: Any,
+) -> FinalResponse:
+    """Create response when evidence is insufficient.
+
+    Args:
+        state: Current state.
+        draft: Draft answer.
+        citations: Available citations.
+        grounding: Grounding result.
+
+    Returns:
+        Final response with follow-up question.
+    """
+    question = state["question"]
+    issues = grounding.issues
+
+    # Generate follow-up questions
+    follow_up = await _generate_followup_questions(question, issues)
+
+    # Decide whether to withhold or provide partial answer
+    counters = state.get("counters")
+    max_attempts_reached = counters and counters.retrieval_attempts >= 2
+
+    if max_attempts_reached or grounding.evidence_coverage < 0.3:
+        # Withhold answer completely
+        return FinalResponse(
+            answer="현재 문서로는 확답을 드리기 어렵습니다.",
+            citations=citations,
+            follow_up_question=follow_up,
+            withheld=True,
+            withheld_reason="관련 문서의 근거가 충분하지 않습니다.",
+        )
+    else:
+        # Provide partial answer with disclaimer
+        return FinalResponse(
+            answer=f"참고: 아래 답변은 제한된 근거에 기반합니다.\n\n{draft.content}",
+            citations=citations,
+            follow_up_question=follow_up,
+            withheld=False,
+            withheld_reason=None,
+        )
+
+
+async def _create_conflict_response(
+    state: AgentState,
+    draft: Any,
+    citations: list[Citation],
+    grounding: Any,
+) -> FinalResponse:
+    """Create response when documents conflict.
+
+    Args:
+        state: Current state.
+        draft: Draft answer.
+        citations: Available citations.
+        grounding: Grounding result.
+
+    Returns:
+        Final response noting conflict.
+    """
+    # Find most recent citation for recommendation
+    recommended = _find_most_recent_citation(citations)
+
+    conflict_notice = (
+        "주의: 문서 간 상충되는 정보가 발견되었습니다. "
+        "아래는 가장 최신 문서를 기준으로 한 답변입니다. "
+        "정확한 정보는 담당자에게 확인해 주세요.\n\n"
+    )
+
+    return FinalResponse(
+        answer=conflict_notice + draft.content,
+        citations=[recommended] if recommended else citations,
+        follow_up_question=None,
+        withheld=False,
+        withheld_reason="문서 간 상충",
+    )
+
+
+def _create_off_topic_response() -> FinalResponse:
+    """Create response for off-topic queries.
+
+    Returns:
+        Final response for out-of-scope.
+    """
+    return FinalResponse(
+        answer="죄송합니다. 해당 질문은 매장 운영과 관련되지 않아 답변드리기 어렵습니다. "
+        "매장 운영, 정책, 절차에 관한 질문을 해주세요.",
+        citations=[],
+        follow_up_question=None,
+        withheld=True,
+        withheld_reason="범위 외 질문",
+    )
+
+
+def _create_error_response(state: AgentState, error: str) -> dict[str, Any]:
+    """Create error response.
+
+    Args:
+        state: Current state.
+        error: Error message.
+
+    Returns:
+        Response dictionary with error.
+    """
+    errors = state.get("errors", [])
+    errors.append(f"Finalize error: {error}")
+
+    return {
+        "final": FinalResponse(
+            answer="죄송합니다. 답변을 생성하는 중 오류가 발생했습니다.",
+            citations=[],
+            follow_up_question=None,
+            withheld=True,
+            withheld_reason=error,
+        ),
+        "errors": errors,
+    }
+
+
+async def _generate_followup_questions(
+    question: str, issues: list[str]
+) -> str | None:
+    """Generate follow-up questions using LLM.
+
+    Args:
+        question: Original question.
+        issues: List of grounding issues.
+
+    Returns:
+        Follow-up question or None.
+    """
+    try:
+        llm = ChatOpenAI(model="gpt-4o-mini", temperature=0.3)
+        structured_llm = llm.with_structured_output(FollowUpQuestions)
+
+        user_message = FOLLOWUP_USER_TEMPLATE.format(
+            question=question,
+            issues="\n".join(issues) if issues else "근거 부족",
+        )
+
+        result: FollowUpQuestions = await structured_llm.ainvoke(
+            [
+                {"role": "system", "content": FOLLOWUP_SYSTEM_PROMPT},
+                {"role": "user", "content": user_message},
+            ]
+        )
+
+        # Return first question as the follow-up
+        if result.questions:
+            return result.questions[0]
+        return None
+
+    except Exception as e:
+        logger.warning(f"Failed to generate follow-up questions: {e}")
+        # Fallback generic question
+        return "질문을 더 구체적으로 해주시겠어요?"
+
+
+def _find_most_recent_citation(citations: list[Citation]) -> Citation | None:
+    """Find citation with most recent effective_date.
+
+    Args:
+        citations: List of citations.
+
+    Returns:
+        Most recent citation or None.
+    """
+    if not citations:
+        return None
+
+    citations_with_dates = [c for c in citations if c.effective_date]
+    if not citations_with_dates:
+        # Return highest score if no dates
+        return max(citations, key=lambda c: c.score)
+
+    return max(citations_with_dates, key=lambda c: c.effective_date or "")

--- a/agents/store_ops_agent/app/agents/nodes/generate.py
+++ b/agents/store_ops_agent/app/agents/nodes/generate.py
@@ -1,0 +1,277 @@
+"""Generate Node for StoreOps Agent.
+
+This node:
+1. Takes retrieved candidates from state
+2. Generates a draft answer using LLM (3-5 sentences)
+3. Produces 2-3 citations referencing source documents
+4. Returns draft answer with citations used
+"""
+
+import logging
+import time
+from typing import Any
+
+from langchain_openai import ChatOpenAI
+from pydantic import BaseModel, Field
+
+from app.agents.state import (
+    AgentState,
+    DraftAnswer,
+    Intent,
+)
+from app.models.schemas import Citation
+
+logger = logging.getLogger(__name__)
+
+
+class GeneratedAnswer(BaseModel):
+    """Schema for LLM generated answer response."""
+
+    answer: str = Field(
+        description="Generated answer in 3-5 sentences based on retrieved documents"
+    )
+    citations_used: list[str] = Field(
+        description="List of chunk_ids used to generate the answer (2-3 citations)"
+    )
+    confidence: float = Field(
+        ge=0.0, le=1.0, description="Confidence in the generated answer"
+    )
+
+
+GENERATION_SYSTEM_PROMPT = """You are a helpful store operations assistant that answers questions based on provided documents.
+
+Instructions:
+1. Answer the question in 3-5 sentences using ONLY information from the provided context.
+2. Use 2-3 citations from the context to support your answer.
+3. If the context doesn't contain enough information, indicate uncertainty.
+4. Write in Korean (한국어) unless the user asks in another language.
+5. Be concise and focus on the most relevant information.
+
+Context documents will be provided with their chunk_ids. Reference these in your citations_used.
+
+Important:
+- Do NOT make up information not present in the context
+- If documents conflict, mention the discrepancy
+- Provide practical, actionable information when possible"""
+
+
+GENERATION_USER_TEMPLATE = """질문: {question}
+
+검색된 문서:
+{context}
+
+위 문서를 기반으로 질문에 답변해주세요. 답변에 사용한 문서의 chunk_id를 citations_used에 포함해주세요."""
+
+
+async def generate_node(state: AgentState) -> dict[str, Any]:
+    """Generate draft answer from retrieved documents.
+
+    Args:
+        state: Current agent state with retrieval results.
+
+    Returns:
+        Dictionary with draft answer.
+    """
+    start_time = time.time()
+
+    # Get retrieval results
+    retrieval = state.get("retrieval")
+    if retrieval is None or not retrieval.candidates:
+        return _create_no_context_response(state, start_time)
+
+    question = state["question"]
+    parsed = state.get("parsed")
+
+    # Check if query is out of scope
+    if parsed and parsed.intent == Intent.OUT_OF_SCOPE:
+        return _create_out_of_scope_response(state, start_time)
+
+    try:
+        # Build context from candidates
+        context = _build_context(retrieval.candidates)
+
+        # Generate answer using LLM
+        llm = ChatOpenAI(model="gpt-4o-mini", temperature=0.1)
+        structured_llm = llm.with_structured_output(GeneratedAnswer)
+
+        user_message = GENERATION_USER_TEMPLATE.format(
+            question=question,
+            context=context,
+        )
+
+        result: GeneratedAnswer = await structured_llm.ainvoke(
+            [
+                {"role": "system", "content": GENERATION_SYSTEM_PROMPT},
+                {"role": "user", "content": user_message},
+            ]
+        )
+
+        # Validate citations exist in candidates
+        valid_citations = _validate_citations(result.citations_used, retrieval.candidates)
+
+        draft = DraftAnswer(
+            content=result.answer,
+            citations_used=valid_citations,
+            model="gpt-4o-mini",
+        )
+
+        latency_ms = (time.time() - start_time) * 1000
+        logger.info(
+            f"Generate completed: {len(valid_citations)} citations, "
+            f"latency={latency_ms:.1f}ms"
+        )
+
+        # Update metrics
+        current_metrics = state.get("metrics")
+        if current_metrics:
+            current_metrics.generate_latency_ms = latency_ms
+
+        return {
+            "draft": draft,
+            "metrics": current_metrics,
+        }
+
+    except Exception as e:
+        logger.error(f"Generate failed: {e}")
+        errors = state.get("errors", [])
+        errors.append(f"Generate error: {e}")
+
+        # Fallback to simple extraction
+        draft = _create_fallback_draft(retrieval.candidates)
+
+        return {
+            "draft": draft,
+            "errors": errors,
+        }
+
+
+def _build_context(candidates: list[Citation]) -> str:
+    """Build context string from candidates.
+
+    Args:
+        candidates: List of citation candidates.
+
+    Returns:
+        Formatted context string.
+    """
+    context_parts = []
+    for i, citation in enumerate(candidates, 1):
+        context_parts.append(
+            f"[문서 {i}]\n"
+            f"- chunk_id: {citation.chunk_id}\n"
+            f"- 제목: {citation.title}\n"
+            f"- 내용: {citation.snippet}\n"
+            f"- 관련도 점수: {citation.score:.2f}\n"
+        )
+
+    return "\n".join(context_parts)
+
+
+def _validate_citations(
+    citations_used: list[str], candidates: list[Citation]
+) -> list[str]:
+    """Validate that cited chunk_ids exist in candidates.
+
+    Args:
+        citations_used: List of chunk_ids claimed to be used.
+        candidates: List of actual candidates.
+
+    Returns:
+        List of valid chunk_ids.
+    """
+    valid_chunk_ids = {c.chunk_id for c in candidates}
+    validated = [cid for cid in citations_used if cid in valid_chunk_ids]
+
+    # If no valid citations, use top candidates
+    if not validated and candidates:
+        validated = [c.chunk_id for c in candidates[:2]]
+
+    return validated
+
+
+def _create_fallback_draft(candidates: list[Citation]) -> DraftAnswer:
+    """Create fallback draft from candidates without LLM.
+
+    Args:
+        candidates: List of citation candidates.
+
+    Returns:
+        Simple draft answer.
+    """
+    if not candidates:
+        return DraftAnswer(
+            content="관련 문서를 찾을 수 없습니다.",
+            citations_used=[],
+            model="fallback",
+        )
+
+    # Use top candidate's snippet as basis
+    top_candidate = candidates[0]
+    answer = f"검색된 문서에 따르면: {top_candidate.snippet}"
+
+    return DraftAnswer(
+        content=answer,
+        citations_used=[candidates[0].chunk_id] if candidates else [],
+        model="fallback",
+    )
+
+
+def _create_no_context_response(
+    state: AgentState, start_time: float
+) -> dict[str, Any]:
+    """Create response when no context is available.
+
+    Args:
+        state: Current agent state.
+        start_time: Start time for latency calculation.
+
+    Returns:
+        Dictionary with empty draft.
+    """
+    latency_ms = (time.time() - start_time) * 1000
+
+    current_metrics = state.get("metrics")
+    if current_metrics:
+        current_metrics.generate_latency_ms = latency_ms
+
+    draft = DraftAnswer(
+        content="관련 문서를 찾을 수 없습니다. 다른 키워드로 검색해 주세요.",
+        citations_used=[],
+        model="none",
+    )
+
+    return {
+        "draft": draft,
+        "metrics": current_metrics,
+    }
+
+
+def _create_out_of_scope_response(
+    state: AgentState, start_time: float
+) -> dict[str, Any]:
+    """Create response for out-of-scope queries.
+
+    Args:
+        state: Current agent state.
+        start_time: Start time for latency calculation.
+
+    Returns:
+        Dictionary with out-of-scope draft.
+    """
+    latency_ms = (time.time() - start_time) * 1000
+
+    current_metrics = state.get("metrics")
+    if current_metrics:
+        current_metrics.generate_latency_ms = latency_ms
+
+    draft = DraftAnswer(
+        content="죄송합니다. 해당 질문은 매장 운영과 관련되지 않아 답변드리기 어렵습니다. "
+        "매장 운영, 정책, 절차에 관한 질문을 해주세요.",
+        citations_used=[],
+        model="out_of_scope",
+    )
+
+    return {
+        "draft": draft,
+        "metrics": current_metrics,
+    }

--- a/agents/store_ops_agent/app/agents/nodes/grounding_check.py
+++ b/agents/store_ops_agent/app/agents/nodes/grounding_check.py
@@ -1,0 +1,328 @@
+"""Grounding Check Node for StoreOps Agent.
+
+This node:
+1. Takes draft answer and citations from state
+2. Verifies that the answer is grounded in the citations
+3. Checks for evidence coverage and conflicts
+4. Returns verdict: pass/insufficient/conflict/off_topic
+"""
+
+import logging
+import time
+from typing import Any
+
+from langchain_openai import ChatOpenAI
+from pydantic import BaseModel, Field
+
+from app.agents.state import (
+    AgentState,
+    GroundingCheckResult,
+    GroundingVerdict,
+)
+from app.models.schemas import Citation
+
+logger = logging.getLogger(__name__)
+
+# Thresholds
+MIN_CITATIONS_REQUIRED = 2
+MIN_EVIDENCE_COVERAGE = 0.6
+
+
+class GroundingEvaluation(BaseModel):
+    """Schema for LLM grounding evaluation response."""
+
+    is_grounded: bool = Field(
+        description="Whether the answer is fully supported by the citations"
+    )
+    evidence_coverage: float = Field(
+        ge=0.0, le=1.0, description="Percentage of answer claims supported by evidence"
+    )
+    has_conflicts: bool = Field(
+        description="Whether there are conflicting statements in the citations"
+    )
+    unsupported_claims: list[str] = Field(
+        default_factory=list,
+        description="List of claims in the answer not supported by citations",
+    )
+    reasoning: str = Field(description="Brief explanation of the evaluation")
+
+
+GROUNDING_SYSTEM_PROMPT = """You are a fact-checking assistant that evaluates whether an answer is properly grounded in source documents.
+
+Your task:
+1. Check if EVERY claim in the answer is supported by the provided citations
+2. Calculate evidence coverage (0.0-1.0): what percentage of claims are supported
+3. Detect any conflicts between citations
+4. List any unsupported claims
+
+Evaluation criteria:
+- is_grounded: True only if ALL major claims are supported by citations
+- evidence_coverage: 1.0 if fully supported, lower for partial support
+- has_conflicts: True if citations contain contradictory information
+
+Be strict in your evaluation. If information is implied but not explicitly stated, consider it unsupported."""
+
+
+GROUNDING_USER_TEMPLATE = """답변:
+{answer}
+
+사용된 인용문:
+{citations}
+
+위 답변이 인용문에 의해 적절히 뒷받침되는지 평가해주세요."""
+
+
+async def grounding_check_node(state: AgentState) -> dict[str, Any]:
+    """Check if draft answer is properly grounded in citations.
+
+    Args:
+        state: Current agent state with draft answer.
+
+    Returns:
+        Dictionary with grounding check result.
+    """
+    start_time = time.time()
+
+    draft = state.get("draft")
+    retrieval = state.get("retrieval")
+
+    # Handle edge cases
+    if draft is None:
+        return _create_insufficient_result(
+            state, start_time, "No draft answer to evaluate"
+        )
+
+    if draft.model in ["none", "out_of_scope", "fallback"]:
+        return _handle_special_draft(state, draft, start_time)
+
+    if retrieval is None or not retrieval.candidates:
+        return _create_insufficient_result(
+            state, start_time, "No citations available for grounding"
+        )
+
+    # Check minimum citations
+    used_citations = _get_used_citations(draft.citations_used, retrieval.candidates)
+    if len(used_citations) < MIN_CITATIONS_REQUIRED:
+        return _create_insufficient_result(
+            state,
+            start_time,
+            f"Insufficient citations: {len(used_citations)} < {MIN_CITATIONS_REQUIRED}",
+        )
+
+    try:
+        # Build citations context
+        citations_text = _build_citations_text(used_citations)
+
+        # Evaluate grounding using LLM
+        llm = ChatOpenAI(model="gpt-4o-mini", temperature=0)
+        structured_llm = llm.with_structured_output(GroundingEvaluation)
+
+        user_message = GROUNDING_USER_TEMPLATE.format(
+            answer=draft.content,
+            citations=citations_text,
+        )
+
+        result: GroundingEvaluation = await structured_llm.ainvoke(
+            [
+                {"role": "system", "content": GROUNDING_SYSTEM_PROMPT},
+                {"role": "user", "content": user_message},
+            ]
+        )
+
+        # Determine verdict
+        verdict, issues, action = _determine_verdict(result, len(used_citations))
+
+        grounding_result = GroundingCheckResult(
+            verdict=verdict,
+            evidence_coverage=result.evidence_coverage,
+            issues=issues,
+            recommended_action=action,
+        )
+
+        latency_ms = (time.time() - start_time) * 1000
+        logger.info(
+            f"Grounding check completed: verdict={verdict.value}, "
+            f"coverage={result.evidence_coverage:.2f}, latency={latency_ms:.1f}ms"
+        )
+
+        # Update metrics
+        current_metrics = state.get("metrics")
+        if current_metrics:
+            current_metrics.grounding_latency_ms = latency_ms
+
+        return {
+            "grounding": grounding_result,
+            "metrics": current_metrics,
+        }
+
+    except Exception as e:
+        logger.error(f"Grounding check failed: {e}")
+        errors = state.get("errors", [])
+        errors.append(f"Grounding check error: {e}")
+
+        # Fallback: assume insufficient if we can't verify
+        return {
+            "grounding": GroundingCheckResult(
+                verdict=GroundingVerdict.INSUFFICIENT,
+                evidence_coverage=0.0,
+                issues=[f"Evaluation failed: {e}"],
+                recommended_action="retry",
+            ),
+            "errors": errors,
+        }
+
+
+def _get_used_citations(
+    citation_ids: list[str], candidates: list[Citation]
+) -> list[Citation]:
+    """Get Citation objects for used citation IDs.
+
+    Args:
+        citation_ids: List of chunk_ids used in the answer.
+        candidates: All available candidates.
+
+    Returns:
+        List of Citation objects that were used.
+    """
+    id_to_citation = {c.chunk_id: c for c in candidates}
+    return [id_to_citation[cid] for cid in citation_ids if cid in id_to_citation]
+
+
+def _build_citations_text(citations: list[Citation]) -> str:
+    """Build citations text for evaluation.
+
+    Args:
+        citations: List of citations used.
+
+    Returns:
+        Formatted citations text.
+    """
+    parts = []
+    for i, citation in enumerate(citations, 1):
+        parts.append(
+            f"[인용 {i}] (chunk_id: {citation.chunk_id})\n"
+            f"출처: {citation.title}\n"
+            f"내용: {citation.snippet}\n"
+        )
+    return "\n".join(parts)
+
+
+def _determine_verdict(
+    evaluation: GroundingEvaluation, num_citations: int
+) -> tuple[GroundingVerdict, list[str], str | None]:
+    """Determine grounding verdict from evaluation.
+
+    Args:
+        evaluation: LLM evaluation result.
+        num_citations: Number of citations used.
+
+    Returns:
+        Tuple of (verdict, issues list, recommended action).
+    """
+    issues = []
+
+    # Check for conflicts first
+    if evaluation.has_conflicts:
+        issues.append("문서 간 상충되는 정보가 발견되었습니다")
+        return GroundingVerdict.CONFLICT, issues, "resolve_conflict"
+
+    # Check evidence coverage
+    if evaluation.evidence_coverage < MIN_EVIDENCE_COVERAGE:
+        issues.append(f"근거 범위 부족: {evaluation.evidence_coverage:.0%}")
+        issues.extend(evaluation.unsupported_claims)
+        return GroundingVerdict.INSUFFICIENT, issues, "retry_retrieval"
+
+    # Check if grounded
+    if not evaluation.is_grounded:
+        issues.append("일부 주장이 근거로 뒷받침되지 않습니다")
+        issues.extend(evaluation.unsupported_claims)
+        return GroundingVerdict.INSUFFICIENT, issues, "refine_answer"
+
+    # Check citation count
+    if num_citations < MIN_CITATIONS_REQUIRED:
+        issues.append(f"인용 수 부족: {num_citations}")
+        return GroundingVerdict.INSUFFICIENT, issues, "retry_retrieval"
+
+    # All checks passed
+    return GroundingVerdict.PASS, [], None
+
+
+def _handle_special_draft(
+    state: AgentState, draft: Any, start_time: float
+) -> dict[str, Any]:
+    """Handle special draft types (none, out_of_scope, fallback).
+
+    Args:
+        state: Current agent state.
+        draft: Draft answer.
+        start_time: Start time.
+
+    Returns:
+        Appropriate grounding result.
+    """
+    latency_ms = (time.time() - start_time) * 1000
+
+    current_metrics = state.get("metrics")
+    if current_metrics:
+        current_metrics.grounding_latency_ms = latency_ms
+
+    if draft.model == "out_of_scope":
+        return {
+            "grounding": GroundingCheckResult(
+                verdict=GroundingVerdict.OFF_TOPIC,
+                evidence_coverage=0.0,
+                issues=["Query is out of scope"],
+                recommended_action=None,
+            ),
+            "metrics": current_metrics,
+        }
+
+    if draft.model in ["none", "fallback"]:
+        return {
+            "grounding": GroundingCheckResult(
+                verdict=GroundingVerdict.INSUFFICIENT,
+                evidence_coverage=0.0,
+                issues=["No proper context available"],
+                recommended_action="retry_retrieval",
+            ),
+            "metrics": current_metrics,
+        }
+
+    return {
+        "grounding": GroundingCheckResult(
+            verdict=GroundingVerdict.INSUFFICIENT,
+            evidence_coverage=0.0,
+            issues=["Unknown draft type"],
+        ),
+        "metrics": current_metrics,
+    }
+
+
+def _create_insufficient_result(
+    state: AgentState, start_time: float, reason: str
+) -> dict[str, Any]:
+    """Create insufficient grounding result.
+
+    Args:
+        state: Current agent state.
+        start_time: Start time.
+        reason: Reason for insufficiency.
+
+    Returns:
+        Grounding result dictionary.
+    """
+    latency_ms = (time.time() - start_time) * 1000
+
+    current_metrics = state.get("metrics")
+    if current_metrics:
+        current_metrics.grounding_latency_ms = latency_ms
+
+    return {
+        "grounding": GroundingCheckResult(
+            verdict=GroundingVerdict.INSUFFICIENT,
+            evidence_coverage=0.0,
+            issues=[reason],
+            recommended_action="retry_retrieval",
+        ),
+        "metrics": current_metrics,
+    }

--- a/agents/store_ops_agent/app/agents/nodes/parse_classify.py
+++ b/agents/store_ops_agent/app/agents/nodes/parse_classify.py
@@ -1,0 +1,178 @@
+"""Parse and Classify Node for StoreOps Agent.
+
+This node:
+1. Normalizes the user query
+2. Classifies intent (policy_question, procedure_question, general_question, out_of_scope)
+3. Extracts metadata hints for filtering (category, store_type, effective_date)
+4. Returns normalized_query, intent, confidence, and filters
+"""
+
+import logging
+import re
+import time
+from typing import Any
+
+from langchain_openai import ChatOpenAI
+from pydantic import BaseModel, Field
+
+from app.agents.state import (
+    AgentFilters,
+    AgentState,
+    Intent,
+    ParsedQuery,
+)
+
+logger = logging.getLogger(__name__)
+
+
+class QueryClassification(BaseModel):
+    """Schema for LLM query classification response."""
+
+    normalized_query: str = Field(
+        description="Normalized query with typos corrected and key terms preserved"
+    )
+    intent: str = Field(
+        description="Intent classification: policy_question, procedure_question, general_question, or out_of_scope"
+    )
+    confidence: float = Field(
+        ge=0.0, le=1.0, description="Confidence score for classification"
+    )
+    category: str | None = Field(
+        default=None,
+        description="Detected category: refund, promo, inventory, cs, operation, hr",
+    )
+    store_type: str | None = Field(
+        default=None,
+        description="Detected store type: cafe, convenience, apparel, restaurant, retail",
+    )
+    reasoning: str = Field(description="Brief reasoning for the classification")
+
+
+CLASSIFICATION_SYSTEM_PROMPT = """You are a query classifier for a store operations Q&A system.
+
+Your tasks:
+1. Normalize the query: fix typos, remove unnecessary words, but preserve key terms
+2. Classify the intent:
+   - policy_question: Questions about rules, regulations, policies (환불 규정, 근무 시간 등)
+   - procedure_question: Questions about how to do something (절차, 방법, 프로세스)
+   - general_question: General information queries
+   - out_of_scope: Questions unrelated to store operations (weather, personal, etc.)
+3. Extract metadata hints if present:
+   - category: refund(환불), promo(프로모션), inventory(재고), cs(고객서비스), operation(운영), hr(인사)
+   - store_type: cafe(카페), convenience(편의점), apparel(의류), restaurant(레스토랑), retail(소매)
+
+Examples:
+- "카페에서 환불 처리 어떻게 해요?" -> intent: procedure_question, category: refund, store_type: cafe
+- "편의점 야간 수당 규정이 뭐예요?" -> intent: policy_question, category: hr, store_type: convenience
+- "오늘 날씨 어때?" -> intent: out_of_scope
+
+Respond in JSON format matching the schema."""
+
+
+async def parse_classify_node(state: AgentState) -> dict[str, Any]:
+    """Parse and classify the user query.
+
+    Args:
+        state: Current agent state with question.
+
+    Returns:
+        Dictionary with parsed query and updated filters.
+    """
+    start_time = time.time()
+    question = state["question"]
+    existing_filters = state.get("filters", AgentFilters())
+
+    try:
+        # Use LLM for classification
+        llm = ChatOpenAI(model="gpt-4o-mini", temperature=0)
+        structured_llm = llm.with_structured_output(QueryClassification)
+
+        result: QueryClassification = await structured_llm.ainvoke(
+            [
+                {"role": "system", "content": CLASSIFICATION_SYSTEM_PROMPT},
+                {"role": "user", "content": question},
+            ]
+        )
+
+        # Map intent string to enum
+        intent_map = {
+            "policy_question": Intent.POLICY_QUESTION,
+            "procedure_question": Intent.PROCEDURE_QUESTION,
+            "general_question": Intent.GENERAL_QUESTION,
+            "out_of_scope": Intent.OUT_OF_SCOPE,
+        }
+        intent = intent_map.get(result.intent.lower(), Intent.GENERAL_QUESTION)
+
+        # Create parsed query
+        parsed = ParsedQuery(
+            normalized_query=result.normalized_query,
+            intent=intent,
+            confidence=result.confidence,
+            extracted_entities={
+                "category": result.category,
+                "store_type": result.store_type,
+                "reasoning": result.reasoning,
+            },
+        )
+
+        # Update filters with extracted values (only if not already set)
+        updated_filters = AgentFilters(
+            category=existing_filters.category or result.category,
+            store_type=existing_filters.store_type or result.store_type,
+            effective_date=existing_filters.effective_date,
+            language=existing_filters.language,
+        )
+
+        latency_ms = (time.time() - start_time) * 1000
+        logger.info(
+            f"Parse/Classify completed: intent={intent.value}, "
+            f"confidence={result.confidence:.2f}, latency={latency_ms:.1f}ms"
+        )
+
+        # Update metrics
+        current_metrics = state.get("metrics")
+        if current_metrics:
+            current_metrics.parse_latency_ms = latency_ms
+
+        return {
+            "parsed": parsed,
+            "filters": updated_filters,
+            "metrics": current_metrics,
+        }
+
+    except Exception as e:
+        logger.error(f"Parse/Classify failed: {e}")
+        latency_ms = (time.time() - start_time) * 1000
+
+        # Fallback to simple normalization
+        parsed = ParsedQuery(
+            normalized_query=_simple_normalize(question),
+            intent=Intent.GENERAL_QUESTION,
+            confidence=0.5,
+            extracted_entities={"error": str(e)},
+        )
+
+        errors = state.get("errors", [])
+        errors.append(f"Parse/Classify error: {e}")
+
+        return {
+            "parsed": parsed,
+            "filters": existing_filters,
+            "errors": errors,
+        }
+
+
+def _simple_normalize(query: str) -> str:
+    """Simple query normalization fallback.
+
+    Args:
+        query: Original query string.
+
+    Returns:
+        Normalized query string.
+    """
+    # Remove extra whitespace
+    normalized = " ".join(query.split())
+    # Remove special characters except Korean, alphanumeric, and basic punctuation
+    normalized = re.sub(r"[^\w\s가-힣.,?!]", "", normalized)
+    return normalized.strip()

--- a/agents/store_ops_agent/app/agents/nodes/retrieve.py
+++ b/agents/store_ops_agent/app/agents/nodes/retrieve.py
@@ -1,0 +1,346 @@
+"""Retrieve Node for StoreOps Agent.
+
+This node:
+1. Takes normalized query and filters from state
+2. Searches FAISS vector store with topK (default 8-10)
+3. Applies metadata filtering (post-retrieval for FAISS)
+4. Limits to max_chunks_per_doc=2
+5. Returns candidates with scores
+"""
+
+import logging
+import time
+from collections import defaultdict
+from typing import Any, Optional
+
+from app.agents.state import (
+    AgentCounters,
+    AgentFilters,
+    AgentState,
+    RetrievalResult,
+)
+from app.core.metadata_filter import (
+    FilterRelaxationStrategy,
+    MetadataFilter,
+    MetadataFilterParser,
+)
+from app.indexing.embedder import EmbeddingGenerator
+from app.indexing.vector_store import FAISSVectorStore
+from app.models.schemas import Citation
+
+logger = logging.getLogger(__name__)
+
+# Default configuration
+DEFAULT_TOPK = 8
+MAX_CHUNKS_PER_DOC = 2
+OVERFETCH_MULTIPLIER = 3
+
+
+class VectorStoreManager:
+    """Singleton manager for vector store access."""
+
+    _instance: Optional["VectorStoreManager"] = None
+    _vector_store: Optional[FAISSVectorStore] = None
+    _embedder: Optional[EmbeddingGenerator] = None
+
+    @classmethod
+    def get_instance(cls) -> "VectorStoreManager":
+        """Get singleton instance."""
+        if cls._instance is None:
+            cls._instance = cls()
+        return cls._instance
+
+    @classmethod
+    def set_vector_store(cls, vector_store: FAISSVectorStore) -> None:
+        """Set the vector store to use."""
+        cls._vector_store = vector_store
+
+    @classmethod
+    def set_embedder(cls, embedder: EmbeddingGenerator) -> None:
+        """Set the embedder to use."""
+        cls._embedder = embedder
+
+    @classmethod
+    def get_vector_store(cls) -> Optional[FAISSVectorStore]:
+        """Get the vector store."""
+        return cls._vector_store
+
+    @classmethod
+    def get_embedder(cls) -> Optional[EmbeddingGenerator]:
+        """Get the embedder."""
+        return cls._embedder
+
+
+async def retrieve_node(state: AgentState) -> dict[str, Any]:
+    """Retrieve relevant documents from vector store.
+
+    Args:
+        state: Current agent state with parsed query and filters.
+
+    Returns:
+        Dictionary with retrieval results.
+    """
+    start_time = time.time()
+
+    # Get query from parsed state or fall back to original question
+    parsed = state.get("parsed")
+    query = parsed.normalized_query if parsed else state["question"]
+    topk = state.get("topk", DEFAULT_TOPK)
+    filters = state.get("filters", AgentFilters())
+    counters = state.get("counters", AgentCounters())
+
+    # Increment retrieval attempts
+    counters.retrieval_attempts += 1
+
+    try:
+        # Get vector store and embedder
+        vector_store = VectorStoreManager.get_vector_store()
+        embedder = VectorStoreManager.get_embedder()
+
+        if vector_store is None or embedder is None:
+            logger.warning("Vector store or embedder not initialized")
+            return _create_empty_result(state, counters, start_time)
+
+        # Generate query embedding
+        query_embedding = await _get_query_embedding(query, embedder)
+        if query_embedding is None:
+            logger.error("Failed to generate query embedding")
+            return _create_empty_result(state, counters, start_time)
+
+        # Search with overfetch for filtering
+        overfetch_count = topk * OVERFETCH_MULTIPLIER
+        all_citations = vector_store.search_by_embedding(query_embedding, overfetch_count)
+
+        # Apply metadata filters
+        filtered_citations = _apply_filters(all_citations, filters)
+
+        # If no results and we have filters, try relaxation
+        filter_applied = not _is_filter_empty(filters)
+        if not filtered_citations and filter_applied and counters.retrieval_attempts < 2:
+            logger.info("No results with filters, attempting relaxation")
+            filtered_citations, filters = _relax_and_retry(all_citations, filters)
+
+        # Apply max_chunks_per_doc limit
+        limited_citations = _limit_chunks_per_doc(filtered_citations, MAX_CHUNKS_PER_DOC)
+
+        # Take top-k after filtering
+        final_citations = limited_citations[:topk]
+
+        latency_ms = (time.time() - start_time) * 1000
+        logger.info(
+            f"Retrieve completed: {len(final_citations)} results "
+            f"(from {len(all_citations)} total), latency={latency_ms:.1f}ms"
+        )
+
+        # Update metrics
+        current_metrics = state.get("metrics")
+        if current_metrics:
+            current_metrics.retrieve_latency_ms = latency_ms
+
+        return {
+            "retrieval": RetrievalResult(
+                candidates=final_citations,
+                query_embedding=query_embedding.tolist() if hasattr(query_embedding, "tolist") else list(query_embedding),
+                total_retrieved=len(all_citations),
+                filter_applied=filter_applied,
+            ),
+            "filters": filters,
+            "counters": counters,
+            "metrics": current_metrics,
+        }
+
+    except Exception as e:
+        logger.error(f"Retrieve failed: {e}")
+        errors = state.get("errors", [])
+        errors.append(f"Retrieve error: {e}")
+        return {
+            "retrieval": RetrievalResult(
+                candidates=[],
+                total_retrieved=0,
+                filter_applied=False,
+            ),
+            "counters": counters,
+            "errors": errors,
+        }
+
+
+async def _get_query_embedding(query: str, embedder: EmbeddingGenerator) -> Any:
+    """Get embedding for query.
+
+    Args:
+        query: Query string.
+        embedder: EmbeddingGenerator instance.
+
+    Returns:
+        Query embedding vector.
+    """
+    try:
+        # EmbeddingGenerator.embed_text returns numpy array
+        embedding = embedder.embed_text(query)
+        return embedding
+    except Exception as e:
+        logger.error(f"Failed to embed query: {e}")
+        return None
+
+
+def _apply_filters(
+    citations: list[Citation], filters: AgentFilters
+) -> list[Citation]:
+    """Apply metadata filters to citations.
+
+    Since FAISS doesn't support native filtering, we filter post-retrieval.
+
+    Args:
+        citations: List of retrieved citations.
+        filters: Filters to apply.
+
+    Returns:
+        Filtered list of citations.
+    """
+    if _is_filter_empty(filters):
+        return citations
+
+    filtered = []
+    for citation in citations:
+        # Check category match (from doc_id or metadata in snippet)
+        if filters.category:
+            # Simple heuristic: check if category appears in doc_id or snippet
+            if not _matches_category(citation, filters.category):
+                continue
+
+        # Check store_type match
+        if filters.store_type:
+            if not _matches_store_type(citation, filters.store_type):
+                continue
+
+        # Check effective_date
+        if filters.effective_date and citation.effective_date:
+            try:
+                from datetime import datetime
+
+                doc_date = datetime.strptime(citation.effective_date, "%Y-%m-%d").date()
+                if doc_date > filters.effective_date:
+                    continue
+            except (ValueError, TypeError):
+                pass
+
+        filtered.append(citation)
+
+    return filtered
+
+
+def _matches_category(citation: Citation, category: str) -> bool:
+    """Check if citation matches category filter."""
+    category_lower = category.lower()
+    # Check in doc_id, title, or snippet
+    if category_lower in citation.doc_id.lower():
+        return True
+    if category_lower in citation.title.lower():
+        return True
+    return False
+
+
+def _matches_store_type(citation: Citation, store_type: str) -> bool:
+    """Check if citation matches store_type filter."""
+    store_type_lower = store_type.lower()
+    if store_type_lower in citation.doc_id.lower():
+        return True
+    if store_type_lower in citation.title.lower():
+        return True
+    return False
+
+
+def _is_filter_empty(filters: AgentFilters) -> bool:
+    """Check if all filters are empty."""
+    return all(
+        v is None
+        for v in [filters.category, filters.store_type, filters.effective_date, filters.language]
+    )
+
+
+def _relax_and_retry(
+    all_citations: list[Citation], filters: AgentFilters
+) -> tuple[list[Citation], AgentFilters]:
+    """Relax filters and retry filtering.
+
+    Args:
+        all_citations: All retrieved citations before filtering.
+        filters: Current filters.
+
+    Returns:
+        Tuple of (filtered citations, relaxed filters).
+    """
+    # Convert AgentFilters to MetadataFilter for relaxation
+    try:
+        metadata_filter = MetadataFilterParser.parse(
+            store_type=filters.store_type,
+            category=filters.category,
+            effective_date=filters.effective_date.isoformat() if filters.effective_date else None,
+            language=filters.language,
+        )
+
+        result = FilterRelaxationStrategy.relax_once(metadata_filter)
+        if result.relaxed_filter is None:
+            return [], filters
+
+        # Convert back to AgentFilters
+        relaxed_filters = AgentFilters(
+            store_type=result.relaxed_filter.store_type.value if result.relaxed_filter.store_type else None,
+            category=result.relaxed_filter.category.value if result.relaxed_filter.category else None,
+            effective_date=result.relaxed_filter.effective_date,
+            language=result.relaxed_filter.language.value if result.relaxed_filter.language else None,
+        )
+
+        # Retry filtering with relaxed filters
+        filtered = _apply_filters(all_citations, relaxed_filters)
+        logger.info(f"Relaxed filter (removed {result.removed_field}), got {len(filtered)} results")
+
+        return filtered, relaxed_filters
+
+    except Exception as e:
+        logger.warning(f"Filter relaxation failed: {e}")
+        return [], filters
+
+
+def _limit_chunks_per_doc(
+    citations: list[Citation], max_chunks: int
+) -> list[Citation]:
+    """Limit number of chunks per document.
+
+    Args:
+        citations: List of citations.
+        max_chunks: Maximum chunks per document.
+
+    Returns:
+        Citations with limit applied.
+    """
+    doc_counts: dict[str, int] = defaultdict(int)
+    limited = []
+
+    for citation in citations:
+        if doc_counts[citation.doc_id] < max_chunks:
+            limited.append(citation)
+            doc_counts[citation.doc_id] += 1
+
+    return limited
+
+
+def _create_empty_result(
+    state: AgentState, counters: AgentCounters, start_time: float
+) -> dict[str, Any]:
+    """Create empty retrieval result."""
+    latency_ms = (time.time() - start_time) * 1000
+
+    current_metrics = state.get("metrics")
+    if current_metrics:
+        current_metrics.retrieve_latency_ms = latency_ms
+
+    return {
+        "retrieval": RetrievalResult(
+            candidates=[],
+            total_retrieved=0,
+            filter_applied=False,
+        ),
+        "counters": counters,
+        "metrics": current_metrics,
+    }

--- a/agents/store_ops_agent/app/agents/state.py
+++ b/agents/store_ops_agent/app/agents/state.py
@@ -1,0 +1,260 @@
+"""LangGraph State schema for StoreOps Agent.
+
+This module defines the state schema for the RAG agent workflow:
+Parse/Classify -> Retrieve -> Generate -> Grounding Check -> Finalize
+"""
+
+from dataclasses import dataclass, field
+from datetime import date
+from enum import Enum
+from typing import Any, Optional
+
+from typing_extensions import TypedDict
+
+from app.models.schemas import Citation, Verdict
+
+
+class Intent(str, Enum):
+    """Intent classification for user queries."""
+
+    POLICY_QUESTION = "policy_question"  # 규정/정책 관련 질문
+    PROCEDURE_QUESTION = "procedure_question"  # 절차/프로세스 질문
+    GENERAL_QUESTION = "general_question"  # 일반적인 질문
+    OUT_OF_SCOPE = "out_of_scope"  # 범위 외 질문
+
+
+class GroundingVerdict(str, Enum):
+    """Verdict from grounding check."""
+
+    PASS = "pass"  # 충분한 근거로 답변 가능
+    INSUFFICIENT = "insufficient"  # 근거 부족
+    CONFLICT = "conflict"  # 문서 간 충돌
+    OFF_TOPIC = "off_topic"  # 주제와 무관
+
+
+@dataclass
+class ParsedQuery:
+    """Result of query parsing and classification.
+
+    Attributes:
+        normalized_query: Normalized/cleaned query string.
+        intent: Classified intent of the query.
+        confidence: Confidence score for classification (0-1).
+        extracted_entities: Extracted entities from query.
+    """
+
+    normalized_query: str
+    intent: Intent
+    confidence: float
+    extracted_entities: dict[str, Any] = field(default_factory=dict)
+
+
+@dataclass
+class RetrievalResult:
+    """Result of document retrieval.
+
+    Attributes:
+        candidates: List of retrieved citations.
+        query_embedding: Embedding vector used for search.
+        total_retrieved: Total number of documents retrieved before filtering.
+        filter_applied: Whether metadata filtering was applied.
+    """
+
+    candidates: list[Citation]
+    query_embedding: Optional[list[float]] = None
+    total_retrieved: int = 0
+    filter_applied: bool = False
+
+
+@dataclass
+class DraftAnswer:
+    """Draft answer before grounding check.
+
+    Attributes:
+        content: The draft answer text.
+        citations_used: List of citation IDs used.
+        model: Model used for generation.
+    """
+
+    content: str
+    citations_used: list[str]
+    model: str = "gpt-4o-mini"
+
+
+@dataclass
+class GroundingCheckResult:
+    """Result of grounding check.
+
+    Attributes:
+        verdict: Pass/insufficient/conflict/off_topic.
+        evidence_coverage: Percentage of answer supported by evidence.
+        issues: List of issues found.
+        recommended_action: Suggested action based on verdict.
+    """
+
+    verdict: GroundingVerdict
+    evidence_coverage: float = 0.0
+    issues: list[str] = field(default_factory=list)
+    recommended_action: Optional[str] = None
+
+
+@dataclass
+class FinalResponse:
+    """Final response to return to user.
+
+    Attributes:
+        answer: Final answer text.
+        citations: Supporting citations.
+        follow_up_question: Optional follow-up question if evidence insufficient.
+        withheld: Whether answer was withheld.
+        withheld_reason: Reason for withholding answer.
+    """
+
+    answer: str
+    citations: list[Citation]
+    follow_up_question: Optional[str] = None
+    withheld: bool = False
+    withheld_reason: Optional[str] = None
+
+
+@dataclass
+class AgentCounters:
+    """Counters for loop control and metrics.
+
+    Attributes:
+        retrieval_attempts: Number of retrieval attempts (max 2).
+        generation_attempts: Number of generation attempts.
+    """
+
+    retrieval_attempts: int = 0
+    generation_attempts: int = 0
+
+
+@dataclass
+class AgentMetrics:
+    """Performance metrics for the agent run.
+
+    Attributes:
+        parse_latency_ms: Time spent in parse/classify node.
+        retrieve_latency_ms: Time spent in retrieve node.
+        generate_latency_ms: Time spent in generate node.
+        grounding_latency_ms: Time spent in grounding check node.
+        total_latency_ms: Total processing time.
+    """
+
+    parse_latency_ms: float = 0.0
+    retrieve_latency_ms: float = 0.0
+    generate_latency_ms: float = 0.0
+    grounding_latency_ms: float = 0.0
+    total_latency_ms: float = 0.0
+
+
+@dataclass
+class AgentFilters:
+    """Metadata filters extracted or provided.
+
+    Attributes:
+        category: Document category filter.
+        store_type: Store type filter.
+        effective_date: Date filter for document validity.
+        language: Language filter.
+    """
+
+    category: Optional[str] = None
+    store_type: Optional[str] = None
+    effective_date: Optional[date] = None
+    language: Optional[str] = None
+
+
+class AgentState(TypedDict, total=False):
+    """State schema for the StoreOps RAG Agent.
+
+    This state flows through the agent graph:
+    START -> parse_classify -> retrieve -> generate -> grounding_check -> finalize -> END
+
+    With conditional routing:
+    - If grounding_check verdict is 'insufficient' and retrieval_attempts < 2:
+      -> back to retrieve (with relaxed filters)
+    - Otherwise: -> finalize
+
+    Attributes:
+        trace_id: Unique identifier for request tracing.
+        question: Original user question.
+        filters: Metadata filters (from request or extracted).
+        parsed: Result of parse/classify node.
+        retrieval: Result of retrieve node.
+        draft: Draft answer from generate node.
+        grounding: Result of grounding check.
+        final: Final response to return.
+        counters: Loop control counters.
+        metrics: Performance metrics.
+        errors: List of errors encountered.
+    """
+
+    # Request context
+    trace_id: str
+    question: str
+    topk: int
+
+    # Filters (from request or extracted)
+    filters: AgentFilters
+
+    # Node outputs
+    parsed: ParsedQuery
+    retrieval: RetrievalResult
+    draft: DraftAnswer
+    grounding: GroundingCheckResult
+    final: FinalResponse
+
+    # Control flow
+    counters: AgentCounters
+    metrics: AgentMetrics
+    errors: list[str]
+
+
+def create_initial_state(
+    question: str,
+    trace_id: str,
+    topk: int = 8,
+    store_type: Optional[str] = None,
+    category: Optional[str] = None,
+    effective_date: Optional[str] = None,
+    language: Optional[str] = None,
+) -> AgentState:
+    """Create initial state for a new agent run.
+
+    Args:
+        question: User's question.
+        trace_id: Unique trace ID for the request.
+        topk: Number of documents to retrieve.
+        store_type: Optional store type filter.
+        category: Optional category filter.
+        effective_date: Optional effective date filter (YYYY-MM-DD).
+        language: Optional language filter.
+
+    Returns:
+        Initial AgentState ready for graph execution.
+    """
+    from datetime import datetime
+
+    parsed_date = None
+    if effective_date:
+        try:
+            parsed_date = datetime.strptime(effective_date, "%Y-%m-%d").date()
+        except ValueError:
+            pass
+
+    return AgentState(
+        trace_id=trace_id,
+        question=question,
+        topk=topk,
+        filters=AgentFilters(
+            category=category,
+            store_type=store_type,
+            effective_date=parsed_date,
+            language=language,
+        ),
+        counters=AgentCounters(),
+        metrics=AgentMetrics(),
+        errors=[],
+    )

--- a/agents/store_ops_agent/tests/test_agent_graph.py
+++ b/agents/store_ops_agent/tests/test_agent_graph.py
@@ -1,0 +1,207 @@
+"""Tests for LangGraph Agent Graph workflow."""
+
+from typing import Literal
+from unittest.mock import AsyncMock, MagicMock, patch
+
+import pytest
+
+from app.agents.graph import (
+    MAX_RETRIEVAL_ATTEMPTS,
+    build_agent_graph,
+    get_agent_graph,
+    should_retry_retrieval,
+)
+from app.agents.state import (
+    AgentCounters,
+    AgentFilters,
+    AgentMetrics,
+    AgentState,
+    GroundingCheckResult,
+    GroundingVerdict,
+    create_initial_state,
+)
+
+
+class TestShouldRetryRetrieval:
+    """Tests for should_retry_retrieval routing function."""
+
+    def test_retry_when_insufficient_and_attempts_available(self):
+        """Test retry when insufficient and attempts < max."""
+        state: AgentState = {
+            "trace_id": "test",
+            "question": "test",
+            "topk": 8,
+            "grounding": GroundingCheckResult(
+                verdict=GroundingVerdict.INSUFFICIENT,
+                evidence_coverage=0.4,
+                recommended_action="retry_retrieval",
+            ),
+            "counters": AgentCounters(retrieval_attempts=1),
+            "errors": [],
+            "filters": AgentFilters(),
+            "metrics": AgentMetrics(),
+        }
+        result = should_retry_retrieval(state)
+        assert result == "retrieve"
+
+    def test_no_retry_when_max_attempts_reached(self):
+        """Test no retry when max attempts reached."""
+        state: AgentState = {
+            "trace_id": "test",
+            "question": "test",
+            "topk": 8,
+            "grounding": GroundingCheckResult(
+                verdict=GroundingVerdict.INSUFFICIENT,
+                evidence_coverage=0.4,
+                recommended_action="retry_retrieval",
+            ),
+            "counters": AgentCounters(retrieval_attempts=MAX_RETRIEVAL_ATTEMPTS),
+            "errors": [],
+            "filters": AgentFilters(),
+            "metrics": AgentMetrics(),
+        }
+        result = should_retry_retrieval(state)
+        assert result == "finalize"
+
+    def test_no_retry_when_pass(self):
+        """Test no retry when grounding passes."""
+        state: AgentState = {
+            "trace_id": "test",
+            "question": "test",
+            "topk": 8,
+            "grounding": GroundingCheckResult(
+                verdict=GroundingVerdict.PASS,
+                evidence_coverage=0.95,
+            ),
+            "counters": AgentCounters(retrieval_attempts=1),
+            "errors": [],
+            "filters": AgentFilters(),
+            "metrics": AgentMetrics(),
+        }
+        result = should_retry_retrieval(state)
+        assert result == "finalize"
+
+    def test_no_retry_when_conflict(self):
+        """Test no retry when there's a conflict."""
+        state: AgentState = {
+            "trace_id": "test",
+            "question": "test",
+            "topk": 8,
+            "grounding": GroundingCheckResult(
+                verdict=GroundingVerdict.CONFLICT,
+                evidence_coverage=0.8,
+            ),
+            "counters": AgentCounters(retrieval_attempts=1),
+            "errors": [],
+            "filters": AgentFilters(),
+            "metrics": AgentMetrics(),
+        }
+        result = should_retry_retrieval(state)
+        assert result == "finalize"
+
+    def test_no_retry_when_off_topic(self):
+        """Test no retry when query is off-topic."""
+        state: AgentState = {
+            "trace_id": "test",
+            "question": "test",
+            "topk": 8,
+            "grounding": GroundingCheckResult(
+                verdict=GroundingVerdict.OFF_TOPIC,
+                evidence_coverage=0.0,
+            ),
+            "counters": AgentCounters(retrieval_attempts=1),
+            "errors": [],
+            "filters": AgentFilters(),
+            "metrics": AgentMetrics(),
+        }
+        result = should_retry_retrieval(state)
+        assert result == "finalize"
+
+    def test_finalize_when_no_grounding(self):
+        """Test finalize when no grounding result."""
+        state: AgentState = {
+            "trace_id": "test",
+            "question": "test",
+            "topk": 8,
+            "counters": AgentCounters(retrieval_attempts=1),
+            "errors": [],
+            "filters": AgentFilters(),
+            "metrics": AgentMetrics(),
+        }
+        result = should_retry_retrieval(state)
+        assert result == "finalize"
+
+    def test_no_retry_when_action_not_retry(self):
+        """Test no retry when recommended action is not retry_retrieval."""
+        state: AgentState = {
+            "trace_id": "test",
+            "question": "test",
+            "topk": 8,
+            "grounding": GroundingCheckResult(
+                verdict=GroundingVerdict.INSUFFICIENT,
+                evidence_coverage=0.4,
+                recommended_action="refine_answer",  # Not retry_retrieval
+            ),
+            "counters": AgentCounters(retrieval_attempts=1),
+            "errors": [],
+            "filters": AgentFilters(),
+            "metrics": AgentMetrics(),
+        }
+        result = should_retry_retrieval(state)
+        assert result == "finalize"
+
+
+class TestBuildAgentGraph:
+    """Tests for build_agent_graph function."""
+
+    def test_graph_compiles(self):
+        """Test that graph compiles without errors."""
+        graph = build_agent_graph()
+        assert graph is not None
+
+    def test_graph_has_nodes(self):
+        """Test that graph has expected nodes."""
+        graph = build_agent_graph()
+        # Access the underlying graph nodes
+        nodes = graph.nodes
+        expected_nodes = [
+            "parse_classify",
+            "retrieve",
+            "generate",
+            "grounding_check",
+            "finalize",
+        ]
+        for node_name in expected_nodes:
+            assert node_name in nodes or any(
+                node_name in str(n) for n in nodes
+            ), f"Node {node_name} not found"
+
+
+class TestGetAgentGraph:
+    """Tests for get_agent_graph singleton."""
+
+    def test_singleton_returns_same_instance(self):
+        """Test that get_agent_graph returns same instance."""
+        graph1 = get_agent_graph()
+        graph2 = get_agent_graph()
+        assert graph1 is graph2
+
+
+class TestCreateInitialState:
+    """Tests for create_initial_state function."""
+
+    def test_creates_valid_state(self):
+        """Test that create_initial_state creates valid state."""
+        state = create_initial_state(
+            question="환불 정책이 뭐예요?",
+            trace_id="test_trace_001",
+            topk=10,
+            store_type="cafe",
+        )
+
+        assert state["question"] == "환불 정책이 뭐예요?"
+        assert state["trace_id"] == "test_trace_001"
+        assert state["topk"] == 10
+        assert state["filters"].store_type == "cafe"
+        assert state["counters"].retrieval_attempts == 0
+        assert state["errors"] == []

--- a/agents/store_ops_agent/tests/test_agent_nodes.py
+++ b/agents/store_ops_agent/tests/test_agent_nodes.py
@@ -1,0 +1,268 @@
+"""Tests for LangGraph Agent Node functions."""
+
+from datetime import date
+from unittest.mock import AsyncMock, MagicMock, patch
+
+import pytest
+
+from app.agents.nodes.retrieve import (
+    _apply_filters,
+    _is_filter_empty,
+    _limit_chunks_per_doc,
+    _matches_category,
+    _matches_store_type,
+)
+from app.agents.state import (
+    AgentCounters,
+    AgentFilters,
+    AgentMetrics,
+    AgentState,
+    DraftAnswer,
+    GroundingCheckResult,
+    GroundingVerdict,
+    Intent,
+    ParsedQuery,
+    RetrievalResult,
+)
+from app.models.schemas import Citation
+
+
+class TestRetrieveNodeHelpers:
+    """Tests for retrieve node helper functions."""
+
+    def test_is_filter_empty_true(self):
+        """Test is_filter_empty returns True for empty filters."""
+        filters = AgentFilters()
+        assert _is_filter_empty(filters) is True
+
+    def test_is_filter_empty_false(self):
+        """Test is_filter_empty returns False for non-empty filters."""
+        filters = AgentFilters(category="refund")
+        assert _is_filter_empty(filters) is False
+
+    def test_matches_category_in_doc_id(self):
+        """Test matches_category finds category in doc_id."""
+        citation = Citation(
+            doc_id="refund_policy_001",
+            title="General Policy",
+            chunk_id="chunk_001",
+            snippet="test",
+            score=0.9,
+        )
+        assert _matches_category(citation, "refund") is True
+        assert _matches_category(citation, "promo") is False
+
+    def test_matches_category_in_title(self):
+        """Test matches_category finds category in title."""
+        citation = Citation(
+            doc_id="doc_001",
+            title="환불 정책 안내",
+            chunk_id="chunk_001",
+            snippet="test",
+            score=0.9,
+        )
+        assert _matches_category(citation, "환불") is True
+
+    def test_matches_store_type_in_doc_id(self):
+        """Test matches_store_type finds store_type in doc_id."""
+        citation = Citation(
+            doc_id="cafe_manual_001",
+            title="운영 매뉴얼",
+            chunk_id="chunk_001",
+            snippet="test",
+            score=0.9,
+        )
+        assert _matches_store_type(citation, "cafe") is True
+        assert _matches_store_type(citation, "convenience") is False
+
+    def test_limit_chunks_per_doc(self):
+        """Test limit_chunks_per_doc limits chunks correctly."""
+        citations = [
+            Citation(doc_id="doc_001", title="T1", chunk_id="c1", snippet="s1", score=0.9),
+            Citation(doc_id="doc_001", title="T1", chunk_id="c2", snippet="s2", score=0.85),
+            Citation(doc_id="doc_001", title="T1", chunk_id="c3", snippet="s3", score=0.8),
+            Citation(doc_id="doc_002", title="T2", chunk_id="c4", snippet="s4", score=0.75),
+            Citation(doc_id="doc_002", title="T2", chunk_id="c5", snippet="s5", score=0.7),
+        ]
+        limited = _limit_chunks_per_doc(citations, max_chunks=2)
+
+        # Should have 2 from doc_001 and 2 from doc_002
+        assert len(limited) == 4
+
+        # Count per doc
+        doc_counts = {}
+        for c in limited:
+            doc_counts[c.doc_id] = doc_counts.get(c.doc_id, 0) + 1
+
+        assert doc_counts["doc_001"] == 2
+        assert doc_counts["doc_002"] == 2
+
+    def test_apply_filters_empty(self):
+        """Test apply_filters with empty filters."""
+        citations = [
+            Citation(doc_id="doc_001", title="T1", chunk_id="c1", snippet="s1", score=0.9),
+        ]
+        filters = AgentFilters()
+        result = _apply_filters(citations, filters)
+        assert len(result) == 1  # No filtering
+
+    def test_apply_filters_category(self):
+        """Test apply_filters with category filter."""
+        citations = [
+            Citation(doc_id="refund_001", title="T1", chunk_id="c1", snippet="s1", score=0.9),
+            Citation(doc_id="promo_001", title="T2", chunk_id="c2", snippet="s2", score=0.85),
+        ]
+        filters = AgentFilters(category="refund")
+        result = _apply_filters(citations, filters)
+        assert len(result) == 1
+        assert result[0].doc_id == "refund_001"
+
+
+class TestGroundingCheckHelpers:
+    """Tests for grounding check related functionality."""
+
+    def test_grounding_verdict_pass(self):
+        """Test creating pass verdict."""
+        result = GroundingCheckResult(
+            verdict=GroundingVerdict.PASS,
+            evidence_coverage=0.95,
+        )
+        assert result.verdict == GroundingVerdict.PASS
+        assert result.evidence_coverage == 0.95
+
+    def test_grounding_verdict_insufficient(self):
+        """Test creating insufficient verdict."""
+        result = GroundingCheckResult(
+            verdict=GroundingVerdict.INSUFFICIENT,
+            evidence_coverage=0.4,
+            issues=["근거 부족", "인용 수 부족"],
+            recommended_action="retry_retrieval",
+        )
+        assert result.verdict == GroundingVerdict.INSUFFICIENT
+        assert len(result.issues) == 2
+        assert result.recommended_action == "retry_retrieval"
+
+    def test_grounding_verdict_conflict(self):
+        """Test creating conflict verdict."""
+        result = GroundingCheckResult(
+            verdict=GroundingVerdict.CONFLICT,
+            evidence_coverage=0.8,
+            issues=["문서 간 상충"],
+            recommended_action="resolve_conflict",
+        )
+        assert result.verdict == GroundingVerdict.CONFLICT
+
+
+class TestFinalizeHelpers:
+    """Tests for finalize node functionality."""
+
+    def test_draft_answer_creation(self):
+        """Test creating draft answer."""
+        draft = DraftAnswer(
+            content="환불은 7일 이내 가능합니다.",
+            citations_used=["chunk_001", "chunk_002"],
+            model="gpt-4o-mini",
+        )
+        assert "환불" in draft.content
+        assert len(draft.citations_used) == 2
+
+    def test_parsed_query_creation(self):
+        """Test creating parsed query."""
+        parsed = ParsedQuery(
+            normalized_query="환불 정책이 뭐예요",
+            intent=Intent.POLICY_QUESTION,
+            confidence=0.92,
+            extracted_entities={"category": "refund"},
+        )
+        assert parsed.intent == Intent.POLICY_QUESTION
+        assert parsed.confidence > 0.9
+
+
+class TestAgentStateFlow:
+    """Tests for agent state flow through nodes."""
+
+    def test_state_accumulation(self):
+        """Test that state accumulates through nodes."""
+        # Start with initial state
+        state: AgentState = {
+            "trace_id": "test_001",
+            "question": "환불 정책이 뭐예요?",
+            "topk": 8,
+            "filters": AgentFilters(),
+            "counters": AgentCounters(),
+            "metrics": AgentMetrics(),
+            "errors": [],
+        }
+
+        # After parse_classify
+        state["parsed"] = ParsedQuery(
+            normalized_query="환불 정책이 뭐예요",
+            intent=Intent.POLICY_QUESTION,
+            confidence=0.9,
+        )
+
+        # After retrieve
+        state["retrieval"] = RetrievalResult(
+            candidates=[
+                Citation(
+                    doc_id="doc_001",
+                    title="환불 정책",
+                    chunk_id="chunk_001",
+                    snippet="환불은 7일 이내 가능",
+                    score=0.92,
+                )
+            ],
+            total_retrieved=10,
+        )
+
+        # After generate
+        state["draft"] = DraftAnswer(
+            content="환불은 7일 이내 가능합니다.",
+            citations_used=["chunk_001"],
+        )
+
+        # After grounding
+        state["grounding"] = GroundingCheckResult(
+            verdict=GroundingVerdict.PASS,
+            evidence_coverage=0.95,
+        )
+
+        # Verify all state is present
+        assert state["parsed"] is not None
+        assert state["retrieval"] is not None
+        assert state["draft"] is not None
+        assert state["grounding"] is not None
+        assert state["grounding"].verdict == GroundingVerdict.PASS
+
+    def test_counter_tracking(self):
+        """Test that counters track attempts correctly."""
+        counters = AgentCounters()
+        assert counters.retrieval_attempts == 0
+
+        # Simulate first retrieval
+        counters.retrieval_attempts += 1
+        assert counters.retrieval_attempts == 1
+
+        # Simulate retry
+        counters.retrieval_attempts += 1
+        assert counters.retrieval_attempts == 2
+
+    def test_metrics_tracking(self):
+        """Test that metrics track latency correctly."""
+        metrics = AgentMetrics()
+
+        # Simulate node latencies
+        metrics.parse_latency_ms = 50.0
+        metrics.retrieve_latency_ms = 100.0
+        metrics.generate_latency_ms = 200.0
+        metrics.grounding_latency_ms = 75.0
+
+        # Calculate total
+        metrics.total_latency_ms = (
+            metrics.parse_latency_ms
+            + metrics.retrieve_latency_ms
+            + metrics.generate_latency_ms
+            + metrics.grounding_latency_ms
+        )
+
+        assert metrics.total_latency_ms == 425.0

--- a/agents/store_ops_agent/tests/test_agent_state.py
+++ b/agents/store_ops_agent/tests/test_agent_state.py
@@ -1,0 +1,277 @@
+"""Tests for LangGraph Agent State schema."""
+
+from datetime import date
+
+import pytest
+
+from app.agents.state import (
+    AgentCounters,
+    AgentFilters,
+    AgentMetrics,
+    AgentState,
+    DraftAnswer,
+    FinalResponse,
+    GroundingCheckResult,
+    GroundingVerdict,
+    Intent,
+    ParsedQuery,
+    RetrievalResult,
+    create_initial_state,
+)
+from app.models.schemas import Citation
+
+
+class TestIntent:
+    """Tests for Intent enum."""
+
+    def test_intent_values(self):
+        """Test that all expected intent values exist."""
+        assert Intent.POLICY_QUESTION.value == "policy_question"
+        assert Intent.PROCEDURE_QUESTION.value == "procedure_question"
+        assert Intent.GENERAL_QUESTION.value == "general_question"
+        assert Intent.OUT_OF_SCOPE.value == "out_of_scope"
+
+
+class TestGroundingVerdict:
+    """Tests for GroundingVerdict enum."""
+
+    def test_verdict_values(self):
+        """Test that all expected verdict values exist."""
+        assert GroundingVerdict.PASS.value == "pass"
+        assert GroundingVerdict.INSUFFICIENT.value == "insufficient"
+        assert GroundingVerdict.CONFLICT.value == "conflict"
+        assert GroundingVerdict.OFF_TOPIC.value == "off_topic"
+
+
+class TestParsedQuery:
+    """Tests for ParsedQuery dataclass."""
+
+    def test_create_parsed_query(self):
+        """Test creating a ParsedQuery."""
+        parsed = ParsedQuery(
+            normalized_query="환불 정책이 뭐예요?",
+            intent=Intent.POLICY_QUESTION,
+            confidence=0.95,
+            extracted_entities={"category": "refund"},
+        )
+        assert parsed.normalized_query == "환불 정책이 뭐예요?"
+        assert parsed.intent == Intent.POLICY_QUESTION
+        assert parsed.confidence == 0.95
+        assert parsed.extracted_entities == {"category": "refund"}
+
+    def test_parsed_query_default_entities(self):
+        """Test ParsedQuery with default empty entities."""
+        parsed = ParsedQuery(
+            normalized_query="test",
+            intent=Intent.GENERAL_QUESTION,
+            confidence=0.5,
+        )
+        assert parsed.extracted_entities == {}
+
+
+class TestRetrievalResult:
+    """Tests for RetrievalResult dataclass."""
+
+    def test_create_retrieval_result(self):
+        """Test creating a RetrievalResult."""
+        citation = Citation(
+            doc_id="doc_001",
+            title="Test Document",
+            chunk_id="chunk_001",
+            snippet="Test snippet",
+            score=0.9,
+        )
+        result = RetrievalResult(
+            candidates=[citation],
+            query_embedding=[0.1, 0.2, 0.3],
+            total_retrieved=10,
+            filter_applied=True,
+        )
+        assert len(result.candidates) == 1
+        assert result.total_retrieved == 10
+        assert result.filter_applied is True
+
+    def test_retrieval_result_defaults(self):
+        """Test RetrievalResult default values."""
+        result = RetrievalResult(candidates=[])
+        assert result.query_embedding is None
+        assert result.total_retrieved == 0
+        assert result.filter_applied is False
+
+
+class TestDraftAnswer:
+    """Tests for DraftAnswer dataclass."""
+
+    def test_create_draft_answer(self):
+        """Test creating a DraftAnswer."""
+        draft = DraftAnswer(
+            content="환불은 7일 이내 가능합니다.",
+            citations_used=["chunk_001", "chunk_002"],
+            model="gpt-4o-mini",
+        )
+        assert draft.content == "환불은 7일 이내 가능합니다."
+        assert len(draft.citations_used) == 2
+        assert draft.model == "gpt-4o-mini"
+
+    def test_draft_answer_default_model(self):
+        """Test DraftAnswer default model."""
+        draft = DraftAnswer(content="test", citations_used=[])
+        assert draft.model == "gpt-4o-mini"
+
+
+class TestGroundingCheckResult:
+    """Tests for GroundingCheckResult dataclass."""
+
+    def test_create_grounding_result_pass(self):
+        """Test creating a passing grounding result."""
+        result = GroundingCheckResult(
+            verdict=GroundingVerdict.PASS,
+            evidence_coverage=0.95,
+            issues=[],
+        )
+        assert result.verdict == GroundingVerdict.PASS
+        assert result.evidence_coverage == 0.95
+        assert len(result.issues) == 0
+
+    def test_create_grounding_result_insufficient(self):
+        """Test creating an insufficient grounding result."""
+        result = GroundingCheckResult(
+            verdict=GroundingVerdict.INSUFFICIENT,
+            evidence_coverage=0.4,
+            issues=["근거 부족"],
+            recommended_action="retry_retrieval",
+        )
+        assert result.verdict == GroundingVerdict.INSUFFICIENT
+        assert result.recommended_action == "retry_retrieval"
+
+
+class TestFinalResponse:
+    """Tests for FinalResponse dataclass."""
+
+    def test_create_final_response(self):
+        """Test creating a FinalResponse."""
+        citation = Citation(
+            doc_id="doc_001",
+            title="Test",
+            chunk_id="chunk_001",
+            snippet="snippet",
+            score=0.9,
+        )
+        final = FinalResponse(
+            answer="환불은 가능합니다.",
+            citations=[citation],
+            follow_up_question=None,
+            withheld=False,
+        )
+        assert final.answer == "환불은 가능합니다."
+        assert len(final.citations) == 1
+        assert final.withheld is False
+
+    def test_final_response_withheld(self):
+        """Test creating a withheld FinalResponse."""
+        final = FinalResponse(
+            answer="답변을 드리기 어렵습니다.",
+            citations=[],
+            follow_up_question="질문을 구체적으로 해주세요.",
+            withheld=True,
+            withheld_reason="근거 부족",
+        )
+        assert final.withheld is True
+        assert final.withheld_reason == "근거 부족"
+        assert final.follow_up_question is not None
+
+
+class TestAgentCounters:
+    """Tests for AgentCounters dataclass."""
+
+    def test_default_counters(self):
+        """Test default counter values."""
+        counters = AgentCounters()
+        assert counters.retrieval_attempts == 0
+        assert counters.generation_attempts == 0
+
+    def test_increment_counters(self):
+        """Test incrementing counters."""
+        counters = AgentCounters()
+        counters.retrieval_attempts += 1
+        assert counters.retrieval_attempts == 1
+
+
+class TestAgentMetrics:
+    """Tests for AgentMetrics dataclass."""
+
+    def test_default_metrics(self):
+        """Test default metric values."""
+        metrics = AgentMetrics()
+        assert metrics.parse_latency_ms == 0.0
+        assert metrics.retrieve_latency_ms == 0.0
+        assert metrics.generate_latency_ms == 0.0
+        assert metrics.grounding_latency_ms == 0.0
+        assert metrics.total_latency_ms == 0.0
+
+
+class TestAgentFilters:
+    """Tests for AgentFilters dataclass."""
+
+    def test_default_filters(self):
+        """Test default filter values."""
+        filters = AgentFilters()
+        assert filters.category is None
+        assert filters.store_type is None
+        assert filters.effective_date is None
+        assert filters.language is None
+
+    def test_filters_with_values(self):
+        """Test filters with values."""
+        filters = AgentFilters(
+            category="refund",
+            store_type="cafe",
+            effective_date=date(2024, 1, 1),
+            language="ko",
+        )
+        assert filters.category == "refund"
+        assert filters.store_type == "cafe"
+        assert filters.effective_date == date(2024, 1, 1)
+
+
+class TestCreateInitialState:
+    """Tests for create_initial_state function."""
+
+    def test_create_basic_state(self):
+        """Test creating basic initial state."""
+        state = create_initial_state(
+            question="환불 정책이 뭐예요?",
+            trace_id="test_trace_001",
+        )
+        assert state["question"] == "환불 정책이 뭐예요?"
+        assert state["trace_id"] == "test_trace_001"
+        assert state["topk"] == 8  # default
+        assert state["counters"].retrieval_attempts == 0
+        assert state["errors"] == []
+
+    def test_create_state_with_filters(self):
+        """Test creating state with filters."""
+        state = create_initial_state(
+            question="test",
+            trace_id="test_001",
+            topk=10,
+            store_type="cafe",
+            category="refund",
+            effective_date="2024-01-15",
+            language="ko",
+        )
+        assert state["topk"] == 10
+        assert state["filters"].store_type == "cafe"
+        assert state["filters"].category == "refund"
+        assert state["filters"].effective_date == date(2024, 1, 15)
+        assert state["filters"].language == "ko"
+
+    def test_create_state_with_invalid_date(self):
+        """Test creating state with invalid date format."""
+        state = create_initial_state(
+            question="test",
+            trace_id="test_001",
+            effective_date="invalid-date",
+        )
+        # Invalid date should result in None
+        assert state["filters"].effective_date is None


### PR DESCRIPTION
## Summary
- LangGraph 기반 RAG Agent 워크플로우 구현
- 5개 노드: Parse/Classify → Retrieve → Generate → Grounding Check → Finalize
- 조건부 재검색 로직 (근거 부족 시 최대 1회 재시도)
- 47개 테스트 작성 및 통과

## 구현 내용

### State 스키마 (state.py)
- AgentState TypedDict로 전체 워크플로우 상태 관리
- Intent, GroundingVerdict Enum 정의
- ParsedQuery, RetrievalResult, DraftAnswer, GroundingCheckResult, FinalResponse 데이터클래스

### 노드 구현
| 노드 | 기능 |
|------|------|
| Parse/Classify | LLM 기반 질의 정규화, 의도 분류, 메타데이터 추출 |
| Retrieve | FAISS 검색, 필터링, max_chunks_per_doc=2 제한 |
| Generate | LLM 기반 답변 생성 (3-5문장), citation 생성 |
| Grounding Check | 근거 검증, verdict 판정 (pass/insufficient/conflict/off_topic) |
| Finalize | 최종 응답 생성, follow-up 질문 생성 |

### 그래프 흐름
```
START → parse_classify → retrieve → generate → grounding_check
                            ↑                        ↓
                            └── (if insufficient) ──┘
                                                     ↓
                                                 finalize → END
```

## Test plan
- [x] State 스키마 테스트 (20개)
- [x] 그래프 라우팅 테스트 (11개)
- [x] 노드 헬퍼 함수 테스트 (16개)

## Jira Ticket
https://lukasdeveloperacc.atlassian.net/browse/STOR-6

🤖 Generated with [Claude Code](https://claude.com/claude-code)